### PR TITLE
feat: implement resume upload module with file storage and validation

### DIFF
--- a/src/main/java/com/skillscan/ai/controller/ResumeController.java
+++ b/src/main/java/com/skillscan/ai/controller/ResumeController.java
@@ -1,0 +1,30 @@
+package com.skillscan.ai.controller;
+
+
+import com.skillscan.ai.services.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/resumes")
+@RequiredArgsConstructor
+public class ResumeController {
+
+    private final ResumeService resumeService;
+
+    //  Upload Resume
+    @PostMapping("/upload")
+    public ResponseEntity<String> uploadResume(
+            @RequestParam UUID userId,
+            @RequestParam MultipartFile file
+    ) {
+        resumeService.uploadResume(userId, file);
+        return ResponseEntity.ok("Resume uploaded successfully");
+    }
+
+}

--- a/src/main/java/com/skillscan/ai/controller/ResumeController.java
+++ b/src/main/java/com/skillscan/ai/controller/ResumeController.java
@@ -3,6 +3,7 @@ package com.skillscan.ai.controller;
 
 import com.skillscan.ai.services.ResumeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -18,13 +19,19 @@ public class ResumeController {
     private final ResumeService resumeService;
 
     //  Upload Resume
-    @PostMapping("/upload")
+    @PostMapping("/{userId}")
     public ResponseEntity<String> uploadResume(
-            @RequestParam UUID userId,
-            @RequestParam MultipartFile file
+            @PathVariable UUID userId,
+            @RequestParam("file") MultipartFile file
     ) {
         resumeService.uploadResume(userId, file);
-        return ResponseEntity.ok("Resume uploaded successfully");
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body("Resume uploaded successfully");
     }
-
+    //  todo Resume (Single)
+//    @DeleteMapping("/{resumeId}")
+//    public ResponseEntity<Void> deleteResume(@PathVariable UUID resumeId) {
+//        resumeService.deleteResume(resumeId);
+//        return ResponseEntity.noContent().build();
+//    }
 }

--- a/src/main/java/com/skillscan/ai/controller/UserController.java
+++ b/src/main/java/com/skillscan/ai/controller/UserController.java
@@ -3,8 +3,8 @@ package com.skillscan.ai.controller;
 import com.skillscan.ai.dto.request.UserRequestDTO;
 import com.skillscan.ai.dto.response.UserResponseDTO;
 import com.skillscan.ai.services.UserService;
-import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -13,28 +13,32 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
-@CrossOrigin("*")
 public class UserController {
 
     private final UserService userService;
 
+    //  Create user
     @PostMapping
-    public UserResponseDTO createUser(@Valid  @RequestBody UserRequestDTO dto){
-        return userService.createUser(dto);
+    public ResponseEntity<UserResponseDTO> createUser(@RequestBody UserRequestDTO dto) {
+        return ResponseEntity.ok(userService.createUser(dto));
     }
 
+    //  Get user by ID
     @GetMapping("/{id}")
-    public UserResponseDTO getUser(@PathVariable UUID id){
-        return userService.getUserById(id);
+    public ResponseEntity<UserResponseDTO> getUser(@PathVariable UUID id) {
+        return ResponseEntity.ok(userService.getUserById(id));
     }
 
+    //  Get all users
     @GetMapping
-    public List<UserResponseDTO> getAllUsers() {
-        return userService.getAllUsers();
+    public ResponseEntity<List<UserResponseDTO>> getAllUsers() {
+        return ResponseEntity.ok(userService.getAllUsers());
     }
+
+    //  Delete user (UPDATED)
     @DeleteMapping("/{id}")
-    public String deleteUser(@PathVariable UUID id) {
+    public ResponseEntity<Void> deleteUser(@PathVariable UUID id) {
         userService.deleteUser(id);
-        return "User deleted successfully";
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/skillscan/ai/controller/UserController.java
+++ b/src/main/java/com/skillscan/ai/controller/UserController.java
@@ -3,6 +3,7 @@ package com.skillscan.ai.controller;
 import com.skillscan.ai.dto.request.UserRequestDTO;
 import com.skillscan.ai.dto.response.UserResponseDTO;
 import com.skillscan.ai.services.UserService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -19,7 +20,7 @@ public class UserController {
 
     //  Create user
     @PostMapping
-    public ResponseEntity<UserResponseDTO> createUser(@RequestBody UserRequestDTO dto) {
+    public ResponseEntity<UserResponseDTO> createUser(@Valid @RequestBody UserRequestDTO dto) {
         return ResponseEntity.ok(userService.createUser(dto));
     }
 

--- a/src/main/java/com/skillscan/ai/dto/response/ResumeResponseDTO.java
+++ b/src/main/java/com/skillscan/ai/dto/response/ResumeResponseDTO.java
@@ -1,0 +1,18 @@
+package com.skillscan.ai.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Data
+@Builder
+public class ResumeResponseDTO {
+
+    private UUID id;
+    private String fileName;
+    private String fileType;
+    private String fileUrl;
+    private LocalDateTime uploadedAt;
+}

--- a/src/main/java/com/skillscan/ai/mapper/ResumeMapper.java
+++ b/src/main/java/com/skillscan/ai/mapper/ResumeMapper.java
@@ -1,0 +1,17 @@
+package com.skillscan.ai.mapper;
+
+import com.skillscan.ai.dto.response.ResumeResponseDTO;
+import com.skillscan.ai.model.Resume;
+
+public class ResumeMapper {
+
+    public static ResumeResponseDTO toDTO(Resume resume) {
+        return ResumeResponseDTO.builder()
+                .id(resume.getId())
+                .fileName(resume.getFileName())
+                .fileType(resume.getFileType())
+                .fileUrl("/uploads/" + resume.getFileName())
+                .uploadedAt(resume.getUploadedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/skillscan/ai/model/Resume.java
+++ b/src/main/java/com/skillscan/ai/model/Resume.java
@@ -1,0 +1,31 @@
+package com.skillscan.ai.model;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Entity
+@Table(name = "resumes")
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Resume {
+
+    @Id
+    private UUID id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String fileName;
+    private String fileType;
+    private  String filePath;
+
+    private LocalDateTime uploadedAt;
+
+}

--- a/src/main/java/com/skillscan/ai/repository/ResumeRepository.java
+++ b/src/main/java/com/skillscan/ai/repository/ResumeRepository.java
@@ -1,0 +1,12 @@
+package com.skillscan.ai.repository;
+
+import com.skillscan.ai.model.Resume;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.UUID;
+
+public interface ResumeRepository extends JpaRepository<Resume, UUID> {
+
+    List<Resume> findByUserId(UUID userId);
+}

--- a/src/main/java/com/skillscan/ai/services/ResumeService.java
+++ b/src/main/java/com/skillscan/ai/services/ResumeService.java
@@ -8,4 +8,7 @@ public interface ResumeService {
 
     void uploadResume(UUID userId, MultipartFile file);
 
+    void deleteResumeFile(String filePath);
+    // todo implement in feature
+//    void deleteResume(UUID resumeId);
 }

--- a/src/main/java/com/skillscan/ai/services/ResumeService.java
+++ b/src/main/java/com/skillscan/ai/services/ResumeService.java
@@ -1,0 +1,11 @@
+package com.skillscan.ai.services;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.UUID;
+
+public interface ResumeService {
+
+    void uploadResume(UUID userId, MultipartFile file);
+
+}

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -85,10 +85,10 @@ public class ResumeServiceImpl implements ResumeService {
             throw new BadRequestException("Invalid file path");
         }
 
-        try {
+        try(InputStream is  = file.getInputStream()) {
 
             //  Save file
-            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
+            Files.copy(is, targetLocation, StandardCopyOption.REPLACE_EXISTING);
 
             //  Save metadata
             Resume resume = Resume.builder()
@@ -102,14 +102,15 @@ public class ResumeServiceImpl implements ResumeService {
 
             resumeRepository.save(resume);
 
-        } catch (Exception ex) {
+        } catch (IOException ex) {
 
             //  Cleanup file if DB save fails
             try {
                 Files.deleteIfExists(targetLocation);
             } catch (IOException cleanupEx) {
-                log.error("Failed to delete file: {}", cleanupEx.getMessage());
+                log.error("Failed to delete file during cleanup: {}", targetLocation);
             }
+            log.error("Resume upload failed for userId: {}", userId, ex);
             throw new BaseException("Failed to upload resume: " + ex.getMessage(),
                     HttpStatus.INTERNAL_SERVER_ERROR);
         }

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -118,6 +118,10 @@ public class ResumeServiceImpl implements ResumeService {
     @Override
     public void deleteResumeFile(String filePath) {
         try {
+            Path targetPath = Paths.get(filePath).toAbsolutePath().normalize();
+            if (!targetPath.startsWith(uploadPath)) {
+                throw new BadRequestException("Invalid file path");
+            }
             Files.deleteIfExists(Paths.get(filePath));
         } catch (IOException e) {
             log.error("Failed to delete file: {}", filePath);

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -1,6 +1,5 @@
 package com.skillscan.ai.services.impl;
 
-
 import com.skillscan.ai.exception.BadRequestException;
 import com.skillscan.ai.exception.BaseException;
 import com.skillscan.ai.exception.UserNotFoundException;
@@ -9,13 +8,21 @@ import com.skillscan.ai.model.User;
 import com.skillscan.ai.repository.ResumeRepository;
 import com.skillscan.ai.repository.UserRepository;
 import com.skillscan.ai.services.ResumeService;
+import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.util.unit.DataSize;
 import org.springframework.web.multipart.MultipartFile;
 
-import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.*;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -26,66 +33,148 @@ public class ResumeServiceImpl implements ResumeService {
     private final ResumeRepository resumeRepository;
     private final UserRepository userRepository;
 
-    //  Use stable path
-    private static final String UPLOAD_DIR = "C:/temp/uploads/";
+    private static final Logger log = LoggerFactory.getLogger(ResumeServiceImpl.class);
+    private static final String PDF_CONTENT_TYPE = "application/pdf";
+
+    @Value("${file.upload-dir}")
+    private String uploadDir;
+
+    @Value("${file.max-size}")
+    private DataSize maxFileSize;
+    private Path uploadPath;
+
+    @PostConstruct
+    public void init() {
+        try {
+            this.uploadPath = Paths.get(uploadDir)
+                    .toAbsolutePath()
+                    .normalize();
+
+            Files.createDirectories(uploadPath); //  atomic & cross-platform
+        } catch (IOException ex) {
+            throw new BaseException("Could not initialize upload directory",
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
 
     @Override
     public void uploadResume(UUID userId, MultipartFile file) {
 
-        //  Validate User
+        //  Validate user
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new UserNotFoundException("User not found"));
 
-        //  Validate File
-        if (file == null || file.isEmpty()) {
-            throw new BadRequestException("File must not be empty");
+        //  Validate file
+        validateFile(file);
+
+        String originalFileName = StringUtils.cleanPath(file.getOriginalFilename());
+
+        //  Prevent path traversal
+        if (originalFileName.contains("..")) {
+            throw new BadRequestException("Invalid file path");
         }
 
-        String originalFileName = file.getOriginalFilename();
+        // Generate unique filename
+        String safeFileName= UUID.randomUUID() + ".pdf";
 
-        if (originalFileName == null || originalFileName.trim().isEmpty()) {
-            throw new BadRequestException("Invalid file name");
-        }
+        //  Resolve secure path
+        Path targetLocation = uploadPath.resolve(safeFileName).normalize();
 
-        //  Validate PDF (extension-based, more reliable)
-        if (!originalFileName.toLowerCase().endsWith(".pdf")) {
-            throw new BadRequestException("Only PDF files are allowed");
+        // Check file stays inside upload directory
+        if (!targetLocation.startsWith(uploadPath)) {
+            throw new BadRequestException("Invalid file path");
         }
 
         try {
-            // Create directory if not exists
-            File directory = new File(UPLOAD_DIR);
-            if (!directory.exists()) {
-                boolean created = directory.mkdirs();
-                if (!created) {
-                    throw new BaseException("Failed to create upload directory", HttpStatus.INTERNAL_SERVER_ERROR);
-                }
-            }
 
-            //  Generate unique file name
-            String uniqueFileName = UUID.randomUUID() + "_" + originalFileName;
+            //  Save file
+            Files.copy(file.getInputStream(), targetLocation, StandardCopyOption.REPLACE_EXISTING);
 
-            String filePath = UPLOAD_DIR + uniqueFileName;
-
-
-            // Save file
-            File destinationFile = new File(filePath);
-            file.transferTo(destinationFile);
-
-            //  Save metadata to DB
+            //  Save metadata
             Resume resume = Resume.builder()
                     .id(UUID.randomUUID())
                     .user(user)
                     .fileName(originalFileName)
-                    .fileType(file.getContentType())
-                    .filePath(filePath)
+                    .fileType(PDF_CONTENT_TYPE)
+                    .filePath(targetLocation.toString())
                     .uploadedAt(LocalDateTime.now())
                     .build();
 
             resumeRepository.save(resume);
 
+        } catch (Exception ex) {
+
+            //  Cleanup file if DB save fails
+            try {
+                Files.deleteIfExists(targetLocation);
+            } catch (IOException cleanupEx) {
+                log.error("Failed to delete file: {}", cleanupEx.getMessage());
+            }
+            throw new BaseException("Failed to upload resume: " + ex.getMessage(),
+                    HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+    // File deletion logic (used by UserService)
+    @Override
+    public void deleteResumeFile(String filePath) {
+        try {
+            Files.deleteIfExists(Paths.get(filePath));
         } catch (IOException e) {
-            throw new BaseException("Failed to upload resume", HttpStatus.INTERNAL_SERVER_ERROR);
+            log.error("Failed to delete file: {}", filePath);
+        }
+    }
+
+    //  Validation logic
+    private void validateFile(MultipartFile file) {
+
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException("File must not be empty");
+        }
+
+        //  Size validation (from config)
+        if (file.getSize() > maxFileSize.toBytes()) {
+            throw new BadRequestException(
+                    "File size must be less than " + maxFileSize.toMegabytes() + "MB"
+            );
+        }
+
+        String fileName = file.getOriginalFilename();
+
+        if (fileName == null || fileName.trim().isEmpty()) {
+            throw new BadRequestException("Invalid file name");
+        }
+
+        //  Extension check
+        if (!fileName.toLowerCase().endsWith(".pdf")) {
+            throw new BadRequestException("Only PDF files are allowed");
+        }
+
+        //  MIME type check
+        if (file.getContentType() == null ||
+                !file.getContentType().equalsIgnoreCase(PDF_CONTENT_TYPE)) {
+            throw new BadRequestException("Invalid file type");
+        }
+        //  Real PDF validation
+        validatePdfContent(file);
+    }
+    private void validatePdfContent(MultipartFile file) {
+        try (InputStream is = file.getInputStream()) {
+
+            byte[] header = new byte[5];
+            int read = is.read(header);
+
+            if (read != 5) {
+                throw new BadRequestException("Invalid PDF file");
+            }
+
+            String headerStr = new String(header, StandardCharsets.US_ASCII);
+
+            if (!headerStr.equals("%PDF-")) {
+                throw new BadRequestException("Invalid PDF file");
+            }
+
+        } catch (IOException e) {
+            throw new BadRequestException("Failed to read file");
         }
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -102,7 +102,7 @@ public class ResumeServiceImpl implements ResumeService {
 
             resumeRepository.save(resume);
 
-        } catch (IOException ex) {
+        } catch (Exception ex) {
 
             //  Cleanup file if DB save fails
             try {

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -1,0 +1,91 @@
+package com.skillscan.ai.services.impl;
+
+
+import com.skillscan.ai.exception.BadRequestException;
+import com.skillscan.ai.exception.BaseException;
+import com.skillscan.ai.exception.UserNotFoundException;
+import com.skillscan.ai.model.Resume;
+import com.skillscan.ai.model.User;
+import com.skillscan.ai.repository.ResumeRepository;
+import com.skillscan.ai.repository.UserRepository;
+import com.skillscan.ai.services.ResumeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ResumeServiceImpl implements ResumeService {
+
+    private final ResumeRepository resumeRepository;
+    private final UserRepository userRepository;
+
+    //  Use stable path
+    private static final String UPLOAD_DIR = "C:/temp/uploads/";
+
+    @Override
+    public void uploadResume(UUID userId, MultipartFile file) {
+
+        //  Validate User
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("User not found"));
+
+        //  Validate File
+        if (file == null || file.isEmpty()) {
+            throw new BadRequestException("File must not be empty");
+        }
+
+        String originalFileName = file.getOriginalFilename();
+
+        if (originalFileName == null || originalFileName.trim().isEmpty()) {
+            throw new BadRequestException("Invalid file name");
+        }
+
+        //  Validate PDF (extension-based, more reliable)
+        if (!originalFileName.toLowerCase().endsWith(".pdf")) {
+            throw new BadRequestException("Only PDF files are allowed");
+        }
+
+        try {
+            // Create directory if not exists
+            File directory = new File(UPLOAD_DIR);
+            if (!directory.exists()) {
+                boolean created = directory.mkdirs();
+                if (!created) {
+                    throw new BaseException("Failed to create upload directory", HttpStatus.INTERNAL_SERVER_ERROR);
+                }
+            }
+
+            //  Generate unique file name
+            String uniqueFileName = UUID.randomUUID() + "_" + originalFileName;
+
+            String filePath = UPLOAD_DIR + uniqueFileName;
+
+
+            // Save file
+            File destinationFile = new File(filePath);
+            file.transferTo(destinationFile);
+
+            //  Save metadata to DB
+            Resume resume = Resume.builder()
+                    .id(UUID.randomUUID())
+                    .user(user)
+                    .fileName(originalFileName)
+                    .fileType(file.getContentType())
+                    .filePath(filePath)
+                    .uploadedAt(LocalDateTime.now())
+                    .build();
+
+            resumeRepository.save(resume);
+
+        } catch (IOException e) {
+            throw new BaseException("Failed to upload resume", HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeServiceImpl.java
@@ -165,15 +165,21 @@ public class ResumeServiceImpl implements ResumeService {
         try (InputStream is = file.getInputStream()) {
 
             byte[] header = new byte[5];
-            int read = is.read(header);
+            int totalRead = 0;
 
-            if (read != 5) {
-                throw new BadRequestException("Invalid PDF file");
+            while (totalRead < 5) {
+                int bytesRead = is.read(header, totalRead, 5 - totalRead);
+
+                if (bytesRead == -1) {
+                    throw new BadRequestException("Invalid PDF file");
+                }
+
+                totalRead += bytesRead;
             }
 
             String headerStr = new String(header, StandardCharsets.US_ASCII);
 
-            if (!headerStr.equals("%PDF-")) {
+            if (!"%PDF-".equals(headerStr)) {
                 throw new BadRequestException("Invalid PDF file");
             }
 

--- a/src/main/java/com/skillscan/ai/services/impl/UserServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/UserServiceImpl.java
@@ -5,12 +5,18 @@ import com.skillscan.ai.dto.response.UserResponseDTO;
 import com.skillscan.ai.exception.EmailAlreadyExistsException;
 import com.skillscan.ai.exception.UserNotFoundException;
 import com.skillscan.ai.mapper.UserMapper;
+import com.skillscan.ai.model.Resume;
 import com.skillscan.ai.model.User;
+import com.skillscan.ai.repository.ResumeRepository;
 import com.skillscan.ai.repository.UserRepository;
+import com.skillscan.ai.services.ResumeService;
 import com.skillscan.ai.services.UserService;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -20,29 +26,36 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService {
 
+    private static final Logger log = LoggerFactory.getLogger(UserServiceImpl.class);
+
     private final UserRepository userRepository;
+    private final ResumeRepository resumeRepository;
+    private final ResumeService resumeService;
+
+    // Create User
     @Override
     public UserResponseDTO createUser(UserRequestDTO dto) {
 
-       final User user = UserMapper.toEntity(dto);
+        final User user = UserMapper.toEntity(dto);
+
         try {
-           final User savedUser = userRepository.save(user);
+            final User savedUser = userRepository.save(user);
             return UserMapper.toDTO(savedUser);
         } catch (DataIntegrityViolationException ex) {
             throw new EmailAlreadyExistsException("Email already exists");
         }
-
     }
 
-
-
+    // Get User by ID
     @Override
     public UserResponseDTO getUserById(UUID id) {
         User user = userRepository.findById(id)
-                .orElseThrow(()->new UserNotFoundException("User not found with id: " + id));
+                .orElseThrow(() -> new UserNotFoundException("User not found with id: " + id));
+
         return UserMapper.toDTO(user);
     }
 
+    // Get All Users
     @Override
     public List<UserResponseDTO> getAllUsers() {
         return userRepository.findAll()
@@ -51,8 +64,30 @@ public class UserServiceImpl implements UserService {
                 .collect(Collectors.toList());
     }
 
+    //  DELETE USER (App-level cleanup)
     @Override
+    @Transactional
     public void deleteUser(UUID id) {
-        userRepository.deleteById(id);
+
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new UserNotFoundException("User not found with id: " + id));
+
+        //  Fetch all resumes
+        List<Resume> resumes = resumeRepository.findByUserId(id);
+
+        //  Delete files from disk
+        for (Resume resume : resumes) {
+            try {
+                resumeService.deleteResumeFile(resume.getFilePath());
+            } catch (Exception ex) {
+                log.error("Failed to delete resume file: {}", resume.getFilePath());
+            }
+        }
+
+        // Delete resume records
+        resumeRepository.deleteAll(resumes);
+
+        // Delete user
+        userRepository.delete(user);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,31 +1,41 @@
 spring:
   application:
-    name: skillscan-ai-backend  # Application name
+    name: skillscan-ai-backend
 
   datasource:
-    url: jdbc:postgresql://localhost:5433/skillscan_db  # Database URL
-    username: skillscan_user  # DB username
-    password: skillscan_password  # DB password
-    driver-class-name: org.postgresql.Driver  # PostgreSQL driver
+    url: jdbc:postgresql://localhost:5433/skillscan_db
+    username: skillscan_user
+    password: skillscan_password
+    driver-class-name: org.postgresql.Driver
 
   jpa:
     hibernate:
-      ddl-auto: none  # Disable auto table creation (use Flyway)
-    show-sql: true  # Show SQL queries in console
+      ddl-auto: none
+    show-sql: true
     properties:
       hibernate:
-        format_sql: true  # Format SQL output
+        format_sql: true
         jdbc:
-          time_zone: Asia/Kolkata  # Set DB timezone
+          time_zone: Asia/Kolkata
 
   jackson:
-    time-zone: Asia/Kolkata  # JSON timezone
+    time-zone: Asia/Kolkata
 
   flyway:
-    enabled: true  # Enable Flyway migrations
-    baseline-on-migrate: true  # Handle existing DB safely
+    enabled: true
+    baseline-on-migrate: true
 
+  #  Multipart config
+  servlet:
+    multipart:
+      max-file-size: 1MB
+      max-request-size: 1MB
 
-# Set App to port 8081
+# File upload path config
+file:
+  upload-dir: ${UPLOAD_DIR:/var/data/resumes}
+  max-size: 1MB
+
+# Server config
 server:
   port: 8081

--- a/src/main/resources/db/migration/V4__create_resume_table.sql
+++ b/src/main/resources/db/migration/V4__create_resume_table.sql
@@ -1,0 +1,8 @@
+CREATE TABLE resumes (
+    id UUID PRIMARY KEY,
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    file_name VARCHAR(255),
+    file_type VARCHAR(50),
+    file_path TEXT,
+    uploaded_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);

--- a/src/main/resources/db/migration/V5__remove_resume_cascade.sql
+++ b/src/main/resources/db/migration/V5__remove_resume_cascade.sql
@@ -1,0 +1,9 @@
+-- Remove existing foreign key constraint
+ALTER TABLE resumes
+DROP CONSTRAINT IF EXISTS resumes_user_id_fkey;
+
+-- Recreate without cascade
+ALTER TABLE resumes
+ADD CONSTRAINT resumes_user_id_fkey
+FOREIGN KEY (user_id)
+REFERENCES users(id);


### PR DESCRIPTION
This PR introduces the Resume Upload Module (Phase 2) for the SkillScan AI backend.

###  Features
- Implemented resume upload API using MultipartFile
- Added local file storage (C:/temp/uploads/)
- Stored resume metadata in database
- Established User (1) → Resume (Many) relationship

###  Validation & Error Handling
- Validates user existence before upload
- Ensures file is not empty
- Restricts uploads to PDF files only
- Added custom exception handling using BaseException, BadRequestException, and UserNotFoundException
- Prevented internal error leakage

###  Technical Improvements
- Unique file naming using UUID to prevent overwrite
- Automatic directory creation if not exists
- Clean service-layer implementation with proper separation of concerns

###  Not Included (Future Work)
- Resume fetch API
- Resume download API
- DTO & mapper layer for responses
- Cloud storage integration (S3)

###  Tested
- Successfully tested file upload via Postman (multipart/form-data)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Resume upload endpoint: PDF-only uploads (max 1MB), server-side storage, metadata tracking, returns 201 Created.
  * Resume listing/DTO mapping for returned resume metadata.

* **Bug Fixes**
  * User deletion now cleans up associated resume files and records.

* **Chores**
  * Upload size and storage directory made configurable.
  * Database migrations added to create resumes table and update its foreign-key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->