### PR TITLE
feat: add Redis configuration and local setup via Docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,10 @@
 			<groupId>org.apache.httpcomponents.client5</groupId>
 			<artifactId>httpclient5</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-data-redis</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/skillscan/ai/SkillscanAiBackendApplication.java
+++ b/src/main/java/com/skillscan/ai/SkillscanAiBackendApplication.java
@@ -2,9 +2,11 @@ package com.skillscan.ai;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 
 import java.util.TimeZone;
 
+@EnableCaching
 @SpringBootApplication
 public class SkillscanAiBackendApplication {
 

--- a/src/main/java/com/skillscan/ai/config/RedisConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.skillscan.ai.config;
 
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
@@ -9,7 +10,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.*;
 
 import java.time.Duration;
-
+@EnableCaching
 @Configuration
 public class RedisConfig {
 
@@ -33,11 +34,20 @@ public class RedisConfig {
     }
     @Bean
     public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+
+        RedisSerializationContext.SerializationPair<String> keySerializer =
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer());
+
+        RedisSerializationContext.SerializationPair<Object> valueSerializer =
+                RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer());
+
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofMinutes(10));
+                .serializeKeysWith(keySerializer)
+                .serializeValuesWith(valueSerializer)
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues();
 
         return RedisCacheManager.builder(connectionFactory)
                 .cacheDefaults(config)
                 .build();
     }
-}

--- a/src/main/java/com/skillscan/ai/config/RedisConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RedisConfig.java
@@ -1,0 +1,43 @@
+package com.skillscan.ai.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.*;
+
+import java.time.Duration;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+
+        template.setConnectionFactory(connectionFactory);
+
+        // Key serializer
+        template.setKeySerializer(new StringRedisSerializer());
+
+        // Value serializer (JSON)
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.setHashKeySerializer(new StringRedisSerializer());
+        template.setHashValueSerializer(new GenericJackson2JsonRedisSerializer());
+
+        template.afterPropertiesSet();
+        return template;
+    }
+    @Bean
+    public RedisCacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10));
+
+        return RedisCacheManager.builder(connectionFactory)
+                .cacheDefaults(config)
+                .build();
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,7 +24,12 @@ spring:
   flyway:
     enabled: true
     baseline-on-migrate: true
-
+  # redis
+  data:
+    redis:
+      host: localhost
+      port: 6379
+      timeout: 6000
   #  Multipart config
   servlet:
     multipart:


### PR DESCRIPTION
## Overview
This PR introduces Redis setup for caching support in the application.

## Changes
- Added Redis dependency (spring-boot-starter-data-redis)
- Configured Redis connection properties
- Implemented RedisConfig with proper serializers
- Enabled Spring caching support
- Setup Redis locally using Docker

## Note
Redis is not yet integrated into the service layer.
LLM response caching will be implemented in a follow-up PR.

## Next Steps
- Integrate Redis caching in LLMService
- Add TTL-based caching for AI responses
- Optimize cache key strategy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled application-wide caching using Redis with a default 10-minute cache TTL and null-value caching disabled.
* **Chores**
  * Integrated Redis support and added connection configuration (host, port, timeout) for the application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->