### PR TITLE
Implement Redis caching for LLMService and optimize normalization flow

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -5,21 +5,37 @@ services:
     container_name: skillscan_postgres
 
     environment:
-      POSTGRES_DB: skillscan_db          # Same as application.yml
-      POSTGRES_USER: skillscan_user      # Same as application.yml
-      POSTGRES_PASSWORD: skillscan_password  # Same as application.yml
+      POSTGRES_DB: skillscan_db
+      POSTGRES_USER: skillscan_user
+      POSTGRES_PASSWORD: skillscan_password
 
     ports:
-      - "5433:5432"  # Expose DB port
+      - "5433:5432"
 
     volumes:
-      - postgres_data:/var/lib/postgresql/data  # Persist data
+      - postgres_data:/var/lib/postgresql/data
+
+    networks:
+      - skillscan_network
+
+  redis:
+    image: redis:7
+    container_name: skillscan_redis
+
+    ports:
+      - "6379:6379"
+
+    volumes:
+      - redis_data:/data
+
+    command: ["redis-server", "--appendonly", "yes"]
 
     networks:
       - skillscan_network
 
 volumes:
   postgres_data:
+  redis_data:
 
 networks:
   skillscan_network:

--- a/src/main/java/com/skillscan/ai/config/RedisConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RedisConfig.java
@@ -51,3 +51,4 @@ public class RedisConfig {
                 .cacheDefaults(config)
                 .build();
     }
+}

--- a/src/main/java/com/skillscan/ai/config/RestTemplateConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RestTemplateConfig.java
@@ -12,8 +12,8 @@ public class RestTemplateConfig {
     public RestTemplate restTemplate() {
 
         SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-        factory.setConnectTimeout(10_000);   // 10 sec
-        factory.setReadTimeout(60_000);     // 60 sec
+        factory.setConnectTimeout(120_000);   // 2 min
+        factory.setReadTimeout(300_000);     // 5 min
 
         return new RestTemplate(factory);
     }

--- a/src/main/java/com/skillscan/ai/dto/response/AIResponse.java
+++ b/src/main/java/com/skillscan/ai/dto/response/AIResponse.java
@@ -26,5 +26,4 @@ public class AIResponse {
 
     private List<String> suggestions;
 
-    private boolean llmUsed;
 }

--- a/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
@@ -2,6 +2,7 @@ package com.skillscan.ai.services.impl;
 
 import com.skillscan.ai.dto.request.AnalysisRequestDTO;
 import com.skillscan.ai.dto.response.AIResponse;
+import com.skillscan.ai.exception.ResumeNotFoundException;
 import com.skillscan.ai.model.Resume;
 import com.skillscan.ai.repository.ResumeRepository;
 import com.skillscan.ai.services.AnalysisOrchestratorService;
@@ -28,7 +29,7 @@ public class AnalysisOrchestratorServiceImpl implements AnalysisOrchestratorServ
     public AIResponse analyze(AnalysisRequestDTO request) {
 
         Resume resume = resumeRepository.findById(request.getResumeId())
-                .orElseThrow(() -> new RuntimeException("Resume not found"));
+                .orElseThrow(() -> new ResumeNotFoundException("Resume not found"));
 
         String resumeText = resume.getContent();
         String jd = request.getJobDescription();

--- a/src/main/java/com/skillscan/ai/services/impl/LLMOnlySkillNormalizer.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMOnlySkillNormalizer.java
@@ -6,11 +6,9 @@ import com.skillscan.ai.services.SkillNormalizer;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
+
 
 @Service
 @RequiredArgsConstructor
@@ -19,9 +17,6 @@ public class LLMOnlySkillNormalizer implements SkillNormalizer {
 
     private final LLMService llmService;
 
-    //  cache
-    private final Map<String, List<String>> cache = new HashMap<>();
-
     @Override
     public List<String> normalize(List<String> skills) {
 
@@ -29,45 +24,38 @@ public class LLMOnlySkillNormalizer implements SkillNormalizer {
             return Collections.emptyList();
         }
 
-        String key = skills.toString();
-
-        // Cache check
-        if (cache.containsKey(key)) {
-            return cache.get(key);
-        }
+        List<String> cleanedSkills = skills.stream()
+                .map(s -> s.toLowerCase().trim())
+                .filter(s -> !s.isEmpty())
+                .sorted()
+                .toList();
 
         try {
             String prompt = """
-                Convert the following skills into standard professional keywords.
-                - Merge similar terms
-                - Use industry-standard naming
-                - Keep it concise list
-
-                Skills: %s
-                """.formatted(skills);
+                    Convert the following skills into standard professional keywords.
+                    - Merge similar terms
+                    - Use industry-standard naming
+                    - Keep it concise list
+                    
+                    Skills: %s
+                    """.formatted(cleanedSkills);
 
             AIResponse response = llmService.analyze(prompt, "");
 
             if (response.getSkills() != null && !response.getSkills().isEmpty()) {
 
-                List<String> normalized = response.getSkills().stream()
+                return response.getSkills().stream()
                         .map(s -> s.toLowerCase().trim())
                         .filter(s -> !s.isEmpty())
                         .distinct()
                         .toList();
 
-                cache.put(key, normalized); //  store cache
-                return normalized;
             }
-
         } catch (Exception e) {
-            log.warn("LLM normalization failed, fallback used");
+            log.error("LLM normalization failed", e);
         }
 
         //  fallback clean
-        return skills.stream()
-                .map(s -> s.toLowerCase().trim())
-                .distinct()
-                .toList();
+        return cleanedSkills;
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -5,6 +5,8 @@ import com.skillscan.ai.dto.response.AIResponse;
 import com.skillscan.ai.services.LLMService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,6 +19,25 @@ public class LLMServiceImpl implements LLMService {
     private final OpenAIClient client;
 
     @Override
+
+    @Caching(
+            cacheable = {
+
+                    @Cacheable(
+                            value = "llmCacheWithJD",
+                            key = "T(java.util.Objects).hash(#resumeText + '_' + #jd)",
+                            condition = "#jd != null && !#jd.isBlank()",
+                            unless = "#result.llmScore == 0"
+                    ),
+
+                    @Cacheable(
+                            value = "llmCacheWithoutJD",
+                            key = "T(java.util.Objects).hash(#resumeText)",
+                            condition = "#jd == null || #jd.isBlank()",
+                            unless = "#result.llmScore == 0"
+                    )
+            }
+    )
     public AIResponse analyze(String resumeText, String jd) {
 
         log.info("Calling LLM | resumeLength={} | jdPresent={}",

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -25,14 +25,14 @@ public class LLMServiceImpl implements LLMService {
 
                     @Cacheable(
                             value = "llmCacheWithJD",
-                            key = "T(java.util.Objects).hash(#resumeText + '_' + #jd)",
+                            key = "T(com.skillscan.ai.util.CacheKeyUtil).hashKey(#resumeText, #jd)",
                             condition = "#jd != null && !#jd.isBlank()",
                             unless = "#result.llmScore == 0"
                     ),
 
                     @Cacheable(
                             value = "llmCacheWithoutJD",
-                            key = "T(java.util.Objects).hash(#resumeText)",
+                            key = "T(com.skillscan.ai.util.CacheKeyUtil).hashKey(#resumeText, #jd)",
                             condition = "#jd == null || #jd.isBlank()",
                             unless = "#result.llmScore == 0"
                     )

--- a/src/main/java/com/skillscan/ai/util/CacheKeyUtil.java
+++ b/src/main/java/com/skillscan/ai/util/CacheKeyUtil.java
@@ -1,0 +1,23 @@
+package com.skillscan.ai.util;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
+
+public class CacheKeyUtil {
+
+    public static String hashKey(String... parts) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            for (String part : parts) {
+                if (part != null) {
+                    md.update(part.getBytes(StandardCharsets.UTF_8));
+                }
+            }
+            return Base64.getEncoder().encodeToString(md.digest());
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   # redis
   data:
     redis:
-      host: localhost
+      host: skillscan_redis
       port: 6379
       timeout: 6000
   #  Multipart config


### PR DESCRIPTION

## Overview
This PR introduces Redis-based caching for LLM responses and improves the skill normalization pipeline.

## Changes
- Added caching in LLMService using @Cacheable
- Implemented dynamic cache key based on resume and job description
- Added two separate caches:
  - llmCacheWithJD → for resume + job description analysis
  - llmCacheWithoutJD → for resume-only analysis
- Added condition to avoid caching failed responses
- Removed local in-memory cache (HashMap) from SkillNormalizer
- Standardized skill input (lowercase, trim, sort) before LLM call

## Benefits
- Reduces redundant LLM API calls
- Improves response time
- Ensures consistent cache keys for better hit rate
- Prevents incorrect cache hits between JD and non-JD analysis
- Cleaner and more scalable architecture

## Testing
- Verified cache hit by checking logs (LLM not called on repeated requests)
- Confirmed cache entries in Redis using CLI

## Next Steps
- Add cache metrics (hit/miss tracking)
- Optimize TTL based on use case
- Explore L1 (Caffeine) + L2 (Redis) caching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis service infrastructure for caching LLM analysis results.
  * Implemented intelligent result caching for improved performance.

* **Bug Fixes**
  * Fixed incomplete configuration file.

* **Refactor**
  * Increased request timeout thresholds (connection: 10s → 2min; read: 60s → 5min).
  * Enhanced skill normalization with improved preprocessing (cleaning, filtering, sorting).
  * Refined error handling with domain-specific exceptions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->