### PR TITLE
Setup monitoring stack with Micrometer, Prometheus, and Grafana

### DIFF
--- a/Monitoring/prometheus.yml
+++ b/Monitoring/prometheus.yml
@@ -1,0 +1,14 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: 'skillscan-app'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets:
+          - host.docker.internal:8081
+
+  - job_name: 'prometheus'
+    static_configs:
+      - targets:
+          - skillscan_prometheus:9090

--- a/compose.yml
+++ b/compose.yml
@@ -1,35 +1,50 @@
-
 services:
   postgres:
     image: postgres:16
     container_name: skillscan_postgres
-
     environment:
       POSTGRES_DB: skillscan_db
       POSTGRES_USER: skillscan_user
       POSTGRES_PASSWORD: skillscan_password
-
     ports:
       - "5433:5432"
-
     volumes:
       - postgres_data:/var/lib/postgresql/data
-
     networks:
       - skillscan_network
 
   redis:
     image: redis:7
     container_name: skillscan_redis
-
     ports:
       - "6379:6379"
-
     volumes:
       - redis_data:/data
-
     command: ["redis-server", "--appendonly", "yes"]
+    networks:
+      - skillscan_network
 
+  #  Prometheus
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: skillscan_prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./Monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+    networks:
+      - skillscan_network
+
+  # Grafana
+  grafana:
+    image: grafana/grafana:latest
+    container_name: skillscan_grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
     networks:
       - skillscan_network
 

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,15 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-redis</artifactId>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
@@ -62,7 +62,6 @@ public class AnalysisOrchestratorServiceImpl implements AnalysisOrchestratorServ
                     .matchedKeywords(ruleResult.getMatchedKeywords())
                     .missingKeywords(ruleResult.getMissingKeywords())
                     .suggestions(Collections.emptyList())
-                    .llmUsed(false)
                     .build();
         }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,3 +49,17 @@ server:
 #Ollama
 ollama:
   model: llama3
+
+#Prometheus
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true


### PR DESCRIPTION
## Overview
This PR sets up the monitoring infrastructure for the application using Micrometer, Prometheus, and Grafana.

## Changes
- Integrated Spring Boot Actuator for metrics exposure
- Enabled Prometheus metrics endpoint (/actuator/prometheus)
- Configured Prometheus via Docker Compose for metrics scraping
- Added Grafana service for dashboard visualization

## Why
To establish a monitoring foundation for observing application performance, system health, and future custom metrics like cache efficiency and LLM latency.

## Impact
- Enables real-time metrics collection
- Supports future observability enhancements
- No impact on business logic

## Next Steps
- Add custom metrics (cache hit/miss, LLM latency)
- Create Grafana dashboards for visualization

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Prometheus service for monitoring and collecting application metrics
  * Integrated Grafana dashboard for visualizing collected metrics
  * Enabled Actuator endpoints for metrics exposure to Prometheus

* **Infrastructure**
  * Updated Docker Compose configuration with Prometheus and Grafana services
  * Added monitoring dependencies to support metrics collection and export

<!-- end of auto-generated comment: release notes by coderabbit.ai -->