### PR TITLE
feat: add centralized metrics and manual Redis caching for LLM service

### DIFF
--- a/src/main/java/com/skillscan/ai/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/skillscan/ai/exception/GlobalExceptionHandler.java
@@ -3,7 +3,9 @@ package com.skillscan.ai.exception;
 
 
 import com.skillscan.ai.dto.response.ErrorResponse;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -14,12 +16,17 @@ import org.springframework.web.bind.annotation.*;
 import java.time.LocalDateTime;
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler {
+
+    private final SkillScanAIMetrics metrics;
+
 
     //  Handle Custom Exceptions
     @ExceptionHandler(BaseException.class)
     public ResponseEntity<ErrorResponse> handleBaseException(BaseException ex, HttpServletRequest req) {
 
+        metrics.recordError("base_exception");
         ErrorResponse response = ErrorResponse.builder()
                 .timestamp(LocalDateTime.now())
                 .status(ex.getStatus().value())
@@ -35,6 +42,8 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException ex,
                                                                    HttpServletRequest req) {
+
+        metrics.recordError("validation_error");
 
         String message = ex.getBindingResult()
                 .getFieldErrors()
@@ -57,7 +66,11 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<ErrorResponse> handleOtherExceptions(Exception ex, HttpServletRequest req) {
+
+        metrics.recordError("internal_error");
+
         log.error("Unhandled exception at {}: ", req.getRequestURI(), ex);
+
         ErrorResponse response = ErrorResponse.builder()
                 .timestamp(LocalDateTime.now())
                 .status(HttpStatus.INTERNAL_SERVER_ERROR.value())
@@ -73,6 +86,7 @@ public class GlobalExceptionHandler {
             DataIntegrityViolationException ex,
             HttpServletRequest req) {
 
+        metrics.recordError("db_constraint");
 
         log.error("Database constraint violation at {}: ", req.getRequestURI(), ex);
 
@@ -91,7 +105,10 @@ public class GlobalExceptionHandler {
             AIProcessingException ex,
             HttpServletRequest req) {
 
+        metrics.recordError("ai_processing_error");
+
         log.error("AI processing failed at {}: ", req.getRequestURI(), ex);
+
 
         ErrorResponse response = ErrorResponse.builder()
                 .timestamp(LocalDateTime.now())
@@ -107,6 +124,8 @@ public class GlobalExceptionHandler {
     public ResponseEntity<ErrorResponse> handleAITimeoutException(
             AIProcessingTimeoutException ex,
             HttpServletRequest req) {
+
+        metrics.recordError("ai_timeout");
 
         log.error("AI processing timeout at {}: ", req.getRequestURI(), ex);
 

--- a/src/main/java/com/skillscan/ai/metrics/SkillScanAIMetrics.java
+++ b/src/main/java/com/skillscan/ai/metrics/SkillScanAIMetrics.java
@@ -1,0 +1,106 @@
+package com.skillscan.ai.metrics;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+// Centralized metrics handler using Micrometer (Prometheus/Grafana integration)
+@Component
+@RequiredArgsConstructor
+public class SkillScanAIMetrics {
+
+    // Core registry to register all metrics
+    private final MeterRegistry registry;
+
+    // Counters (increment-only metrics)
+    private Counter llmCallCounter;        // counts LLM API calls
+    private Counter cacheHitCounter;       // counts cache hits
+    private Counter cacheMissCounter;      // counts cache misses
+    private Counter analysisRequestCounter;// counts incoming analysis requests
+
+    // Timers (measure execution time)
+    private Timer llmResponseTimer;        // tracks LLM response latency
+    private Timer analysisTimer;           // tracks full analysis time
+
+    // Gauge (dynamic value)
+    private final AtomicLong activeAnalysis = new AtomicLong(0); // active analysis count
+
+    // Initialize and register all metrics
+    @PostConstruct
+    public void init() {
+
+        llmCallCounter = Counter.builder("skillscanai.metrics.llm.calls")
+                .register(registry);
+
+        cacheHitCounter = Counter.builder("skillscanai.metrics.cache.hit")
+                .register(registry);
+
+        cacheMissCounter = Counter.builder("skillscanai.metrics.cache.miss")
+                .register(registry);
+
+        analysisRequestCounter = Counter.builder("skillscanai.metrics.analysis.requests")
+                .register(registry);
+
+        llmResponseTimer = Timer.builder("skillscanai.metrics.llm.response.time")
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+
+        analysisTimer = Timer.builder("skillscanai.metrics.analysis.time")
+                .publishPercentiles(0.5, 0.95, 0.99)
+                .register(registry);
+
+        // Tracks active analysis count
+        Gauge.builder("skillscanai.metrics.analysis.active", activeAnalysis, AtomicLong::get)
+                .register(registry);
+    }
+
+    // Increment LLM call count
+    public void recordLlmCall() {
+        llmCallCounter.increment();
+    }
+
+    // Increment cache hit count
+    public void recordCacheHit() {
+        cacheHitCounter.increment();
+    }
+
+    // Increment cache miss count
+    public void recordCacheMiss() {
+        cacheMissCounter.increment();
+    }
+
+    // Increment analysis request count
+    public void recordAnalysisRequest() {
+        analysisRequestCounter.increment();
+    }
+
+    // Measure LLM execution time
+    public <T> T timeLlm(Supplier<T> operation) {
+        return llmResponseTimer.record(operation);
+    }
+
+    // Measure analysis time + track active executions
+    public <T> T timeAnalysis(Supplier<T> operation) {
+        activeAnalysis.incrementAndGet();
+        try {
+            return analysisTimer.record(operation);
+        } finally {
+            activeAnalysis.decrementAndGet();
+        }
+    }
+
+    // Record categorized errors using tags
+    public void recordError(String type) {
+        Counter.builder("skillscanai.metrics.error")
+                .tag("type", type)
+                .register(registry)
+                .increment();
+    }
+}

--- a/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
@@ -37,7 +37,7 @@ public class AnalysisOrchestratorServiceImpl implements AnalysisOrchestratorServ
 
             Resume resume = resumeRepository.findById(request.getResumeId())
                     .orElseThrow(() -> {
-                        metrics.recordError("resume_not_found"); // 🔥 metric
+                        metrics.recordError("resume_not_found");
                         return new ResumeNotFoundException("Resume not found");
                     });
 
@@ -90,9 +90,12 @@ public class AnalysisOrchestratorServiceImpl implements AnalysisOrchestratorServ
             } catch (Exception e) {
 
                 //  Track unexpected failures
-                metrics.recordError("analysis_failure");
+                if(!( e instanceof  ResumeNotFoundException)) {
+                    metrics.recordError("analysis_failure");
 
-                log.error("Analysis failed", e);
+                    log.error("Analysis failed", e);
+
+                }
                 throw e;
             }
         });

--- a/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AnalysisOrchestratorServiceImpl.java
@@ -3,6 +3,7 @@ package com.skillscan.ai.services.impl;
 import com.skillscan.ai.dto.request.AnalysisRequestDTO;
 import com.skillscan.ai.dto.response.AIResponse;
 import com.skillscan.ai.exception.ResumeNotFoundException;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
 import com.skillscan.ai.model.Resume;
 import com.skillscan.ai.repository.ResumeRepository;
 import com.skillscan.ai.services.AnalysisOrchestratorService;
@@ -24,48 +25,76 @@ public class AnalysisOrchestratorServiceImpl implements AnalysisOrchestratorServ
     private final ScoringService scoringService;
     private final LLMService llmService;
     private final ResultMerger merger;
+    private final SkillScanAIMetrics metrics;
 
     @Override
     public AIResponse analyze(AnalysisRequestDTO request) {
 
-        Resume resume = resumeRepository.findById(request.getResumeId())
-                .orElseThrow(() -> new ResumeNotFoundException("Resume not found"));
+        //  Track total requests
+        metrics.recordAnalysisRequest();
 
-        String resumeText = resume.getContent();
-        String jd = request.getJobDescription();
+        return metrics.timeAnalysis(() -> {
 
-        boolean isJDMode = jd != null && !jd.isBlank();
+            Resume resume = resumeRepository.findById(request.getResumeId())
+                    .orElseThrow(() -> {
+                        metrics.recordError("resume_not_found"); // 🔥 metric
+                        return new ResumeNotFoundException("Resume not found");
+                    });
 
-        log.info("Analysis started | resumeId={} | JD Mode={}", request.getResumeId(), isJDMode);
+            String resumeText = resume.getContent();
+            String jd = request.getJobDescription();
 
-        // RULE SCORING (ALWAYS SAFE)
-        AIResponse ruleResult = isJDMode
-                ? scoringService.calculateWithJD(resumeText, jd)
-                : scoringService.calculateWithoutJD(resumeText);
+            boolean isJDMode = jd != null && !jd.isBlank();
 
-        //  LLM (OPTIONAL)
-        AIResponse llmResult = null;
+            log.info("Analysis started | resumeId={} | JD Mode={}",
+                    request.getResumeId(), isJDMode);
 
-        try {
-            llmResult = llmService.analyze(resumeText, jd);
-        } catch (Exception e) {
-            log.warn("LLM failed, fallback to rule-based only");
-        }
+            try {
 
-        //  FALLBACK
-        if (llmResult == null || llmResult.getLlmScore() <= 0) {
-            return AIResponse.builder()
-                    .finalScore(ruleResult.getRuleScore())
-                    .ruleScore(ruleResult.getRuleScore())
-                    .llmScore(0)
-                    .skills(ruleResult.getSkills())
-                    .matchedKeywords(ruleResult.getMatchedKeywords())
-                    .missingKeywords(ruleResult.getMissingKeywords())
-                    .suggestions(Collections.emptyList())
-                    .build();
-        }
+                //  RULE SCORING
+                AIResponse ruleResult = isJDMode
+                        ? scoringService.calculateWithJD(resumeText, jd)
+                        : scoringService.calculateWithoutJD(resumeText);
 
-        //  MERGE
-        return merger.merge(ruleResult, llmResult);
+                //  LLM (optional)
+                AIResponse llmResult = null;
+
+                try {
+                    llmResult = llmService.analyze(resumeText, jd);
+                } catch (Exception e) {
+                    log.warn("LLM failed, fallback to rule-based only");
+
+                    //  Track LLM failure
+                    metrics.recordError("llm_failure");
+                }
+
+                //  FALLBACK
+                if (llmResult == null || llmResult.getLlmScore() <= 0) {
+
+                    metrics.recordError("llm_fallback"); // track fallback usage
+
+                    return AIResponse.builder()
+                            .finalScore(ruleResult.getRuleScore())
+                            .ruleScore(ruleResult.getRuleScore())
+                            .llmScore(0)
+                            .skills(ruleResult.getSkills())
+                            .matchedKeywords(ruleResult.getMatchedKeywords())
+                            .missingKeywords(ruleResult.getMissingKeywords())
+                            .suggestions(Collections.emptyList())
+                            .build();
+                }
+
+                //  MERGE
+                return merger.merge(ruleResult, llmResult);
+
+            } catch (Exception e) {
+
+                //  Track unexpected failures
+                metrics.recordError("analysis_failure");
+
+                log.error("Analysis failed", e);
+                throw e;
+            }
+        });
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -30,7 +30,15 @@ public class LLMServiceImpl implements LLMService {
         String key = CacheKeyUtil.hashKey(resumeText, jd);
 
         //  Check Cache
-        AIResponse cached = (AIResponse) redisTemplate.opsForValue().get(key);
+        AIResponse cached =null;
+        try{
+
+            cached = (AIResponse) redisTemplate.opsForValue().get(key);
+
+        }catch (Exception e){
+            log.warn("Redis GET failed, proceeding without cache | key={}", key, e);
+            metrics.recordError("cache_error");
+        }
 
         if (cached != null) {
             log.info("Cache HIT | key={}", key);
@@ -56,7 +64,13 @@ public class LLMServiceImpl implements LLMService {
 
             // Store in Redis (only valid response)
             if (response.getLlmScore() > 0) {
-                redisTemplate.opsForValue().set(key, response, CACHE_TTL);
+                try{
+                    redisTemplate.opsForValue().set(key, response, CACHE_TTL);
+                } catch (Exception e) {
+                    log.warn("Redis SET failed, returning response without caching | key={}", key, e);
+                    metrics.recordError("cache_error");
+                }
+
             }
 
             return response;

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -2,13 +2,15 @@ package com.skillscan.ai.services.impl;
 
 import com.skillscan.ai.client.OpenAIClient;
 import com.skillscan.ai.dto.response.AIResponse;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
 import com.skillscan.ai.services.LLMService;
+import com.skillscan.ai.util.CacheKeyUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.cache.annotation.Caching;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
+import java.time.Duration;
 import java.util.List;
 
 @Service
@@ -17,53 +19,70 @@ import java.util.List;
 public class LLMServiceImpl implements LLMService {
 
     private final OpenAIClient client;
+    private final SkillScanAIMetrics metrics;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    private static final Duration CACHE_TTL = Duration.ofMinutes(10);
 
     @Override
-
-    @Caching(
-            cacheable = {
-
-                    @Cacheable(
-                            value = "llmCacheWithJD",
-                            key = "T(com.skillscan.ai.util.CacheKeyUtil).hashKey(#resumeText, #jd)",
-                            condition = "#jd != null && !#jd.isBlank()",
-                            unless = "#result.llmScore == 0"
-                    ),
-
-                    @Cacheable(
-                            value = "llmCacheWithoutJD",
-                            key = "T(com.skillscan.ai.util.CacheKeyUtil).hashKey(#resumeText, #jd)",
-                            condition = "#jd == null || #jd.isBlank()",
-                            unless = "#result.llmScore == 0"
-                    )
-            }
-    )
     public AIResponse analyze(String resumeText, String jd) {
 
-        log.info("Calling LLM | resumeLength={} | jdPresent={}",
-                resumeText != null ? resumeText.length() : 0,
-                jd != null && !jd.isBlank());
+        String key = CacheKeyUtil.hashKey(resumeText, jd);
 
-        String prompt = """
+        //  Check Cache
+        AIResponse cached = (AIResponse) redisTemplate.opsForValue().get(key);
+
+        if (cached != null) {
+            log.info("Cache HIT | key={}", key);
+            metrics.recordCacheHit();
+            return cached;
+        }
+
+        log.info("Cache MISS | key={}", key);
+        metrics.recordCacheMiss();
+
+        try {
+            //  Call LLM with timing
+            AIResponse response = metrics.timeLlm(() -> {
+                metrics.recordLlmCall();
+                return client.callAI(buildPrompt(resumeText, jd));
+            });
+
+            //  Validate response
+            if (response == null) {
+                metrics.recordError("llm_null_response");
+                return fallback();
+            }
+
+            // Store in Redis (only valid response)
+            if (response.getLlmScore() > 0) {
+                redisTemplate.opsForValue().set(key, response, CACHE_TTL);
+            }
+
+            return response;
+
+        } catch (Exception e) {
+            log.error("LLMService failed", e);
+            metrics.recordError("llm_exception");
+            return fallback();
+        }
+    }
+
+    //  Prompt Builder
+    private String buildPrompt(String resumeText, String jd) {
+        return """
         You are an AI resume analyzer.
 
         TASK:
         Analyze the resume and (if provided) job description.
 
-        Return ONLY valid JSON (no extra text) in this format:
+        Return ONLY valid JSON (no extra text):
 
         {
           "score": number (0-100),
-          "skills": [list of standardized skills],
-          "suggestions": [list of improvements]
+          "skills": [],
+          "suggestions": []
         }
-
-        RULES:
-        - Normalize all skills to industry-standard keywords
-        - Merge duplicates (ReactJS → React, Spring Boot → Spring)
-        - Support ALL domains (software, mechanical, electrical, etc.)
-        - Keep output concise
-        - Do NOT include explanation outside JSON
 
         RESUME:
         %s
@@ -74,22 +93,9 @@ public class LLMServiceImpl implements LLMService {
                 resumeText == null ? "" : resumeText,
                 jd == null ? "" : jd
         );
-
-        try {
-            AIResponse response = client.callAI(prompt);
-
-            if (response == null) {
-                return fallback();
-            }
-
-            return response;
-
-        } catch (Exception e) {
-            log.error("LLMService failed", e);
-            return fallback();
-        }
     }
 
+    //  Fallback
     private AIResponse fallback() {
         return AIResponse.builder()
                 .llmScore(0)


### PR DESCRIPTION
##  Overview
This PR introduces centralized metrics and manual Redis caching to improve observability, performance, and control over caching behavior in the SkillScan AI backend.

##  Key Changes
- Implemented SkillScanAIMetrics for managing all application metrics using Micrometer
- Added counters for:
  - LLM API calls
  - Cache hit/miss
  - Analysis requests
- Added timers for:
  - LLM response latency
  - Full analysis execution time
- Introduced tagged error metrics for better monitoring in Prometheus/Grafana
- Replaced Spring @Cacheable with manual Redis caching for:
  - Better debugging
  - Cache hit/miss tracking
  - Explicit TTL control
- Integrated metrics into:
  - LLMServiceImpl
  - AnalysisOrchestratorServiceImpl
  - GlobalExceptionHandler

##  Benefits
- Improved observability with Prometheus metrics
- Accurate cache hit/miss tracking
- Better control over caching strategy
- Enhanced debugging and monitoring capabilities
- Production-ready metrics design

##  Testing
- Verified cache hit/miss via logs and Redis CLI
- Confirmed metrics exposure at `/actuator/prometheus`
- Validated error tracking through simulated failures

##  Notes
- Removed dependency on @Cacheable for better transparency and control
- Metrics naming follows `skillscanai.metrics.*` convention

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive metrics tracking for error monitoring, analysis performance, and LLM operations
  * Implemented explicit Redis caching optimization for AI analysis responses

* **Improvements**
  * Enhanced error tracking with categorized error metrics and recording
  * Integrated performance timing for LLM calls and overall analysis operations
  * Optimized cache management with cache hit/miss tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->