### PR TITLE
Add controller tests with validation and error handling

### DIFF
--- a/src/test/java/com/skillscan/ai/controllerTest/AIAnalysisControllerTest.java
+++ b/src/test/java/com/skillscan/ai/controllerTest/AIAnalysisControllerTest.java
@@ -1,0 +1,98 @@
+package com.skillscan.ai.controllerTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skillscan.ai.controller.AIAnalysisController;
+import com.skillscan.ai.dto.request.AnalysisRequestDTO;
+import com.skillscan.ai.dto.response.AIResponse;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
+import com.skillscan.ai.services.AnalysisOrchestratorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = AIAnalysisController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                UserDetailsServiceAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+class AIAnalysisControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private AnalysisOrchestratorService orchestrator;
+
+    // Required for GlobalExceptionHandler
+    @MockitoBean
+    private SkillScanAIMetrics skillScanAIMetrics;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    //  Success Case
+    @Test
+    void shouldAnalyzeSuccessfully() throws Exception {
+
+        AnalysisRequestDTO request = new AnalysisRequestDTO();
+        request.setResumeId(UUID.randomUUID());
+        request.setJobDescription("Java Developer");
+
+        AIResponse response = AIResponse.builder()
+                .finalScore(85.5)
+                .ruleScore(80)
+                .llmScore(90)
+                .skills(List.of("Java", "Spring Boot"))
+                .matchedKeywords(List.of("Java", "REST"))
+                .missingKeywords(List.of("Docker"))
+                .suggestions(List.of("Learn Docker"))
+                .build();
+
+        when(orchestrator.analyze(request)).thenReturn(response);
+
+        mockMvc.perform(post("/api/analysis")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.finalScore").value(85.5))
+                .andExpect(jsonPath("$.ruleScore").value(80))
+                .andExpect(jsonPath("$.llmScore").value(90))
+                .andExpect(jsonPath("$.skills[0]").value("Java"))
+                .andExpect(jsonPath("$.matchedKeywords[0]").value("Java"))
+                .andExpect(jsonPath("$.missingKeywords[0]").value("Docker"))
+                .andExpect(jsonPath("$.suggestions[0]").value("Learn Docker"));
+    }
+
+    //  Validation Case (Missing resumeId)
+    @Test
+    void shouldReturnBadRequest_whenResumeIdMissing() throws Exception {
+
+        AnalysisRequestDTO request = new AnalysisRequestDTO();
+        request.setJobDescription("Java Developer");
+
+        mockMvc.perform(post("/api/analysis")
+                        .contentType(APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/skillscan/ai/controllerTest/ResumeControllerTest.java
+++ b/src/test/java/com/skillscan/ai/controllerTest/ResumeControllerTest.java
@@ -1,0 +1,85 @@
+package com.skillscan.ai.controllerTest;
+
+import com.skillscan.ai.controller.ResumeController;
+import com.skillscan.ai.dto.response.ResumeUploadResponse;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
+import com.skillscan.ai.services.ResumeService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = ResumeController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                UserDetailsServiceAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+class ResumeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ResumeService resumeService;
+
+    //  Required because GlobalExceptionHandler depends on it
+    @MockitoBean
+    private SkillScanAIMetrics skillScanAIMetrics;
+
+    //  Success Case
+    @Test
+    void shouldUploadResume() throws Exception {
+
+        UUID userId = UUID.randomUUID();
+
+        MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "resume.pdf",
+                "application/pdf",
+                "dummy content".getBytes()
+        );
+
+        ResumeUploadResponse response = ResumeUploadResponse.builder()
+                .resumeId(UUID.randomUUID())
+                .fileName("resume.pdf")
+                .message("Uploaded successfully")
+                .build();
+
+        when(resumeService.uploadResume(any(), any())).thenReturn(response);
+
+        mockMvc.perform(multipart("/api/resumes/{userId}", userId)
+                        .file(file))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.fileName").value("resume.pdf"))
+                .andExpect(jsonPath("$.message").value("Uploaded successfully"));
+    }
+
+    //  Failure Case (Missing File)
+    @Test
+    void shouldReturnBadRequest_whenFileMissing() throws Exception {
+
+        UUID userId = UUID.randomUUID();
+
+        mockMvc.perform(multipart("/api/resumes/{userId}", userId))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/skillscan/ai/controllerTest/UserControllerTest.java
+++ b/src/test/java/com/skillscan/ai/controllerTest/UserControllerTest.java
@@ -1,0 +1,172 @@
+package com.skillscan.ai.controllerTest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.skillscan.ai.controller.UserController;
+import com.skillscan.ai.dto.request.UserRequestDTO;
+import com.skillscan.ai.dto.response.UserResponseDTO;
+import com.skillscan.ai.metrics.SkillScanAIMetrics;
+import com.skillscan.ai.services.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.security.oauth2.client.OAuth2ClientAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.oauth2.resource.servlet.OAuth2ResourceServerAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityFilterAutoConfiguration;
+import org.springframework.boot.autoconfigure.security.servlet.UserDetailsServiceAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(
+        controllers = UserController.class,
+        excludeAutoConfiguration = {
+                SecurityAutoConfiguration.class,
+                SecurityFilterAutoConfiguration.class,
+                UserDetailsServiceAutoConfiguration.class,
+                OAuth2ClientAutoConfiguration.class,
+                OAuth2ResourceServerAutoConfiguration.class
+        }
+)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    @MockitoBean
+    private SkillScanAIMetrics skillScanAIMetrics;
+
+    //  GET ALL USERS
+    @Test
+    void shouldReturnAllUsers() throws Exception {
+        UserResponseDTO user1 = UserResponseDTO.builder()
+                .id(UUID.randomUUID())
+                .name("Alice")
+                .email("alice@mail.com")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        UserResponseDTO user2 = UserResponseDTO.builder()
+                .id(UUID.randomUUID())
+                .name("Bob")
+                .email("bob@mail.com")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userService.getAllUsers()).thenReturn(List.of(user1, user2));
+
+        mockMvc.perform(get("/api/users")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].email").value("alice@mail.com"))
+                .andExpect(jsonPath("$[1].email").value("bob@mail.com"));
+    }
+
+    @Test
+    void shouldReturnEmptyList_whenNoUsersExist() throws Exception {
+        when(userService.getAllUsers()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/users")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+
+    //  GET USER BY ID
+    @Test
+    void shouldReturnUserById() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        UserResponseDTO response = UserResponseDTO.builder()
+                .id(id)
+                .name("Alice")
+                .email("alice@mail.com")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userService.getUserById(id)).thenReturn(response);
+
+        mockMvc.perform(get("/api/users/{id}", id)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("alice@mail.com"))
+                .andExpect(jsonPath("$.name").value("Alice"));
+    }
+
+    //  CREATE USER
+    @Test
+    void shouldCreateUser() throws Exception {
+        UserRequestDTO request = new UserRequestDTO();
+        request.setName("Alice");
+        request.setEmail("alice@mail.com");
+
+        UserResponseDTO response = UserResponseDTO.builder()
+                .id(UUID.randomUUID())
+                .name("Alice")
+                .email("alice@mail.com")
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        when(userService.createUser(any(UserRequestDTO.class))).thenReturn(response);
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.email").value("alice@mail.com"))
+                .andExpect(jsonPath("$.name").value("Alice"));
+    }
+
+    @Test
+    void shouldReturn400_whenNameIsBlank() throws Exception {
+        UserRequestDTO request = new UserRequestDTO();
+        request.setName("");                    // violates @NotBlank
+        request.setEmail("alice@mail.com");
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void shouldReturn400_whenEmailIsInvalid() throws Exception {
+        UserRequestDTO request = new UserRequestDTO();
+        request.setName("Alice");
+        request.setEmail("not-a-valid-email");  // violates @Email
+
+        mockMvc.perform(post("/api/users")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+
+    //  DELETE USER
+    @Test
+    void shouldDeleteUser() throws Exception {
+        UUID id = UUID.randomUUID();
+
+        doNothing().when(userService).deleteUser(id);
+
+        mockMvc.perform(delete("/api/users/{id}", id))
+                .andExpect(status().isNoContent());
+    }
+}


### PR DESCRIPTION
## Overview
This PR introduces controller layer testing for the SkillScan AI backend.

## Changes
- Added tests for:
  - UserController
  - ResumeController (including multipart file upload)
  - AIAnalysisController

## Test Coverage
- Success responses (200, 201)
- Validation errors (400)
- Missing input scenarios (file, resumeId)
- JSON response validation

## Improvements
- Added @Valid in AIAnalysisController to enable request validation
- Fixed error handling in GlobalExceptionHandler (return 400 instead of 500)
- Used @WebMvcTest for isolated controller testing
- Mocked dependencies using @MockitoBean

## Result
- All controller tests passing successfully
- Controller layer is stable and well-tested



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for AI analysis, resume upload, and user management API endpoints, including validation of successful operations and error-handling scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->