### PR TITLE
Implement JWT Logout with Redis Token Blacklisting

### DIFF
--- a/src/main/java/com/skillscan/ai/SkillscanAiBackendApplication.java
+++ b/src/main/java/com/skillscan/ai/SkillscanAiBackendApplication.java
@@ -1,8 +1,11 @@
 package com.skillscan.ai;
 
+import org.springframework.boot.CommandLineRunner;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
@@ -20,5 +23,11 @@ public class SkillscanAiBackendApplication {
 		System.out.println(new BCryptPasswordEncoder().encode("Wasifraza1"));
 		SpringApplication.run(SkillscanAiBackendApplication.class, args);
 	}
-
+	@Bean
+	CommandLineRunner test(StringRedisTemplate redisTemplate) {
+		return args -> {
+			redisTemplate.opsForValue().set("ping", "ok");
+			System.out.println("Redis test: " + redisTemplate.opsForValue().get("ping"));
+		};
+	}
 }

--- a/src/main/java/com/skillscan/ai/config/RedisConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.skillscan.ai.config;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,9 +17,15 @@ import java.time.Duration;
 @Configuration
 public class RedisConfig {
 
+    @Value("${spring.data.redis.host}")
+    private String redisHost;
+
+    @Value("${spring.data.redis.port}")
+    private int redisPort;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        return new LettuceConnectionFactory("localhost", 6379);
+        return new LettuceConnectionFactory(redisHost, redisPort);
     }
 
     @Bean

--- a/src/main/java/com/skillscan/ai/config/RedisConfig.java
+++ b/src/main/java/com/skillscan/ai/config/RedisConfig.java
@@ -6,13 +6,25 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.serializer.*;
 
 import java.time.Duration;
 @EnableCaching
 @Configuration
 public class RedisConfig {
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory("localhost", 6379);
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory connectionFactory) {
+        return new StringRedisTemplate(connectionFactory);
+    }
 
     @Bean
     public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {

--- a/src/main/java/com/skillscan/ai/config/SecurityConfig.java
+++ b/src/main/java/com/skillscan/ai/config/SecurityConfig.java
@@ -8,7 +8,7 @@ import org.springframework.security.authentication.*;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;   // ← add this
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.*;
 import org.springframework.security.web.*;

--- a/src/main/java/com/skillscan/ai/config/SecurityConfig.java
+++ b/src/main/java/com/skillscan/ai/config/SecurityConfig.java
@@ -24,6 +24,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
+                        .requestMatchers("/api/auth/logout").authenticated()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)

--- a/src/main/java/com/skillscan/ai/config/SecurityConfig.java
+++ b/src/main/java/com/skillscan/ai/config/SecurityConfig.java
@@ -4,50 +4,55 @@ import com.skillscan.ai.security.CustomUserDetailsService;
 import com.skillscan.ai.security.JwtAuthFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.*;
-import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.*;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.crypto.bcrypt.*;
+import org.springframework.security.config.http.SessionCreationPolicy;   // ← add this
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.*;
 import org.springframework.security.web.*;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
     private final JwtAuthFilter filter;
+    private final CustomUserDetailsService userDetailsService;
 
     @Bean
     public SecurityFilterChain chain(HttpSecurity http) throws Exception {
         return http
                 .csrf(csrf -> csrf.disable())
+
+                .sessionManagement(sm -> sm
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/api/auth/**").permitAll()
-                        .requestMatchers("/api/auth/logout").authenticated()
                         .anyRequest().authenticated()
                 )
+                .authenticationProvider(authenticationProvider())
                 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
                 .build();
     }
 
     @Bean
-    public BCryptPasswordEncoder passwordEncoder() {
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
+        provider.setUserDetailsService(userDetailsService);
+        provider.setPasswordEncoder(passwordEncoder());
+        return provider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    //  REQUIRED for login
     @Bean
     public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
         return config.getAuthenticationManager();
-    }
-
-    //  REQUIRED for password validation
-    @Bean
-    public DaoAuthenticationProvider authenticationProvider(CustomUserDetailsService service) {
-        DaoAuthenticationProvider provider = new DaoAuthenticationProvider();
-        provider.setUserDetailsService(service);
-        provider.setPasswordEncoder(passwordEncoder());
-        return provider;
     }
 }

--- a/src/main/java/com/skillscan/ai/controller/AuthController.java
+++ b/src/main/java/com/skillscan/ai/controller/AuthController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
 
 import java.util.Map;
 
@@ -59,7 +60,7 @@ public class AuthController {
         String authHeader = request.getHeader("Authorization");
 
         if (authHeader == null || !authHeader.startsWith("Bearer ")) {
-            return ResponseEntity.badRequest().body("No token found");
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("No token found");
         }
 
         String accessToken = authHeader.substring(7);

--- a/src/main/java/com/skillscan/ai/controller/AuthController.java
+++ b/src/main/java/com/skillscan/ai/controller/AuthController.java
@@ -1,10 +1,8 @@
 package com.skillscan.ai.controller;
 
 import com.skillscan.ai.dto.request.LoginRequest;
+import com.skillscan.ai.dto.request.RefreshRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
-import com.skillscan.ai.exception.EmailAlreadyExistsException;
-import com.skillscan.ai.model.User;
-import com.skillscan.ai.model.enums.UserRole;
 import com.skillscan.ai.repository.UserRepository;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.AuthService;
@@ -38,36 +36,13 @@ public class AuthController {
     // LOGIN
     @PostMapping("/login")
     public Map<String, String> login(@RequestBody LoginRequest req) {
-
-        authManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        req.getEmail(),
-                        req.getPassword()
-                )
-        );
-
-        var user = repo.findByEmail(req.getEmail())
-                .orElseThrow(() -> new RuntimeException("User not found"));
-
-        Map<String, String> response = new java.util.LinkedHashMap<>();
-
-        response.put("accessToken", jwt.generateAccessToken(
-                user.getId(),
-                user.getEmail(),
-                user.getRole()
-        ));
-
-        response.put("refreshToken", jwt.generateRefreshToken(
-                user.getId(),
-                user.getEmail(),
-                user.getRole()
-        ));
-
-        return response;
+        return authService.login(req);
     }
     //  REFRESH
     @PostMapping("/refresh")
-    public Map<String, String> refresh(@RequestParam String refreshToken) {
+    public Map<String, String> refresh(@RequestBody RefreshRequest request) {
+
+        String refreshToken = request.getRefreshToken();
 
         jwt.validate(refreshToken, "refresh");
 

--- a/src/main/java/com/skillscan/ai/controller/AuthController.java
+++ b/src/main/java/com/skillscan/ai/controller/AuthController.java
@@ -1,8 +1,11 @@
 package com.skillscan.ai.controller;
 
 import com.skillscan.ai.dto.request.LoginRequest;
+import com.skillscan.ai.dto.request.LogoutRequest;
 import com.skillscan.ai.dto.request.RefreshRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
+import com.skillscan.ai.dto.response.AuthResponse;
+import com.skillscan.ai.dto.response.RefreshResponse;
 import com.skillscan.ai.repository.UserRepository;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.AuthService;
@@ -35,29 +38,23 @@ public class AuthController {
     }
     // LOGIN
     @PostMapping("/login")
-    public Map<String, String> login(@RequestBody LoginRequest req) {
+    public AuthResponse login(@RequestBody LoginRequest req) {
         return authService.login(req);
     }
     //  REFRESH
     @PostMapping("/refresh")
-    public Map<String, String> refresh(@RequestBody RefreshRequest request) {
-
-        String refreshToken = request.getRefreshToken();
-
-        jwt.validate(refreshToken, "refresh");
-
-        return Map.of(
-                "accessToken", jwt.generateAccessToken(
-                        jwt.getUserId(refreshToken),
-                        jwt.getEmail(refreshToken),
-                        jwt.getRole(refreshToken)
-                )
-        );
+    public RefreshResponse refresh(
+            @RequestBody RefreshRequest request
+    ) {
+        return authService.refresh(request);
     }
 
     // LOGOUT
     @PostMapping("/logout")
-    public ResponseEntity<String> logout(HttpServletRequest request) {
+    public ResponseEntity<String> logout(
+            HttpServletRequest request,
+           @Valid @RequestBody LogoutRequest logoutRequest
+    ) {
 
         String authHeader = request.getHeader("Authorization");
 
@@ -65,9 +62,12 @@ public class AuthController {
             return ResponseEntity.badRequest().body("No token found");
         }
 
-        String token = authHeader.substring(7);
+        String accessToken = authHeader.substring(7);
 
-        tokenBlacklistService.blacklistToken(token);
+        authService.logout(
+                accessToken,
+                logoutRequest.getRefreshToken()
+        );
 
         return ResponseEntity.ok("Logged out successfully");
     }

--- a/src/main/java/com/skillscan/ai/controller/AuthController.java
+++ b/src/main/java/com/skillscan/ai/controller/AuthController.java
@@ -8,10 +8,12 @@ import com.skillscan.ai.model.enums.UserRole;
 import com.skillscan.ai.repository.UserRepository;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.AuthService;
+import com.skillscan.ai.services.TokenBlacklistService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.*;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.Map;
@@ -25,6 +27,7 @@ public class AuthController {
     private final UserRepository repo;
     private final JwtTokenProvider jwt;
     private final AuthService authService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     //  REGISTER
     @PostMapping("/register")
@@ -32,11 +35,10 @@ public class AuthController {
         authService.register(req);
         return Map.of("message", "User registered successfully");
     }
-
+    // LOGIN
     @PostMapping("/login")
     public Map<String, String> login(@RequestBody LoginRequest req) {
 
-        //  Use Spring Security (not manual password check)
         authManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         req.getEmail(),
@@ -47,20 +49,23 @@ public class AuthController {
         var user = repo.findByEmail(req.getEmail())
                 .orElseThrow(() -> new RuntimeException("User not found"));
 
-        return Map.of(
-                "accessToken", jwt.generateAccessToken(
-                        user.getId(),
-                        user.getEmail(),
-                        user.getRole()
-                ),
-                "refreshToken", jwt.generateRefreshToken(
-                        user.getId(),
-                        user.getEmail(),
-                        user.getRole()
-                )
-        );
-    }
+        Map<String, String> response = new java.util.LinkedHashMap<>();
 
+        response.put("accessToken", jwt.generateAccessToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole()
+        ));
+
+        response.put("refreshToken", jwt.generateRefreshToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole()
+        ));
+
+        return response;
+    }
+    //  REFRESH
     @PostMapping("/refresh")
     public Map<String, String> refresh(@RequestParam String refreshToken) {
 
@@ -73,5 +78,22 @@ public class AuthController {
                         jwt.getRole(refreshToken)
                 )
         );
+    }
+
+    // LOGOUT
+    @PostMapping("/logout")
+    public ResponseEntity<String> logout(HttpServletRequest request) {
+
+        String authHeader = request.getHeader("Authorization");
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            return ResponseEntity.badRequest().body("No token found");
+        }
+
+        String token = authHeader.substring(7);
+
+        tokenBlacklistService.blacklistToken(token);
+
+        return ResponseEntity.ok("Logged out successfully");
     }
 }

--- a/src/main/java/com/skillscan/ai/controller/AuthController.java
+++ b/src/main/java/com/skillscan/ai/controller/AuthController.java
@@ -38,13 +38,13 @@ public class AuthController {
     }
     // LOGIN
     @PostMapping("/login")
-    public AuthResponse login(@RequestBody LoginRequest req) {
+    public AuthResponse login(@Valid @RequestBody LoginRequest req) {
         return authService.login(req);
     }
     //  REFRESH
     @PostMapping("/refresh")
     public RefreshResponse refresh(
-            @RequestBody RefreshRequest request
+            @Valid @RequestBody RefreshRequest request
     ) {
         return authService.refresh(request);
     }

--- a/src/main/java/com/skillscan/ai/dto/request/LogoutRequest.java
+++ b/src/main/java/com/skillscan/ai/dto/request/LogoutRequest.java
@@ -1,0 +1,11 @@
+package com.skillscan.ai.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class LogoutRequest {
+
+    @NotBlank(message = "Refresh token is required")
+    private String refreshToken;
+}

--- a/src/main/java/com/skillscan/ai/dto/request/RefreshRequest.java
+++ b/src/main/java/com/skillscan/ai/dto/request/RefreshRequest.java
@@ -1,0 +1,16 @@
+package com.skillscan.ai.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class RefreshRequest {
+    private String refreshToken;
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+
+}

--- a/src/main/java/com/skillscan/ai/dto/request/RefreshRequest.java
+++ b/src/main/java/com/skillscan/ai/dto/request/RefreshRequest.java
@@ -2,8 +2,10 @@ package com.skillscan.ai.dto.request;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class RefreshRequest {
     private String refreshToken;

--- a/src/main/java/com/skillscan/ai/dto/response/AuthResponse.java
+++ b/src/main/java/com/skillscan/ai/dto/response/AuthResponse.java
@@ -1,0 +1,12 @@
+package com.skillscan.ai.dto.response;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class AuthResponse {
+
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/skillscan/ai/dto/response/AuthResponse.java
+++ b/src/main/java/com/skillscan/ai/dto/response/AuthResponse.java
@@ -2,9 +2,11 @@ package com.skillscan.ai.dto.response;
 
 import lombok.Builder;
 import lombok.Data;
+import lombok.ToString;
 
 @Data
 @Builder
+@ToString(exclude = {"accessToken","refreshToken"})
 public class AuthResponse {
 
     private String accessToken;

--- a/src/main/java/com/skillscan/ai/dto/response/RefreshResponse.java
+++ b/src/main/java/com/skillscan/ai/dto/response/RefreshResponse.java
@@ -4,10 +4,10 @@ import lombok.*;
 
 @Data
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
 @ToString(exclude = "accessToken")
 public class RefreshResponse {
 
     private String accessToken;
+
+    private String refreshToken;
 }

--- a/src/main/java/com/skillscan/ai/dto/response/RefreshResponse.java
+++ b/src/main/java/com/skillscan/ai/dto/response/RefreshResponse.java
@@ -1,0 +1,13 @@
+package com.skillscan.ai.dto.response;
+
+import lombok.*;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString(exclude = "accessToken")
+public class RefreshResponse {
+
+    private String accessToken;
+}

--- a/src/main/java/com/skillscan/ai/exception/TokenBlacklistException.java
+++ b/src/main/java/com/skillscan/ai/exception/TokenBlacklistException.java
@@ -1,0 +1,10 @@
+package com.skillscan.ai.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class TokenBlacklistException extends BaseException {
+
+    public TokenBlacklistException(String message) {
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/skillscan/ai/exception/TokenHashingException.java
+++ b/src/main/java/com/skillscan/ai/exception/TokenHashingException.java
@@ -1,0 +1,10 @@
+package com.skillscan.ai.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class TokenHashingException extends BaseException{
+
+    public TokenHashingException(String message){
+        super(message, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/com/skillscan/ai/security/CustomUserDetailsService.java
+++ b/src/main/java/com/skillscan/ai/security/CustomUserDetailsService.java
@@ -5,6 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.userdetails.*;
 import org.springframework.stereotype.Service;
 
+import java.util.Locale;
+
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
@@ -13,8 +15,9 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
-        var user = repo.findByEmail(email)
-                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+        String normalized = email.trim().toLowerCase(Locale.ROOT);
+        var user = repo.findByEmail(normalized)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found: " + normalized));
         return new CustomUserDetails(user);
     }
 }

--- a/src/main/java/com/skillscan/ai/security/CustomUserDetailsService.java
+++ b/src/main/java/com/skillscan/ai/security/CustomUserDetailsService.java
@@ -15,6 +15,10 @@ public class CustomUserDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) {
+        if (email == null || email.isBlank()) {
+            throw new UsernameNotFoundException("Email must not be empty");
+                   }
+
         String normalized = email.trim().toLowerCase(Locale.ROOT);
         var user = repo.findByEmail(normalized)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found: " + normalized));

--- a/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
+++ b/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
@@ -22,7 +22,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        return request.getServletPath().startsWith("/api/auth/");
+
+        String path = request.getServletPath();
+        return path.equals("/api/auth/login")
+                || path.equals("/api/auth/register")
+                || path.equals("/api/auth/refresh");
     }
 
     @Override
@@ -53,7 +57,8 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
                 String email = jwt.getEmail(token);
 
-                var userDetails = userDetailsService.loadUserByUsername(email);
+                var userDetails =
+                        userDetailsService.loadUserByUsername(email);
 
                 var auth = new UsernamePasswordAuthenticationToken(
                         userDetails,
@@ -61,9 +66,12 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                         userDetails.getAuthorities()
                 );
 
-                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+                auth.setDetails(
+                        new WebAuthenticationDetailsSource()
+                                .buildDetails(req));
 
-                SecurityContextHolder.getContext().setAuthentication(auth);
+                SecurityContextHolder.getContext()
+                        .setAuthentication(auth);
             }
 
         } catch (Exception e) {

--- a/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
+++ b/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
@@ -1,10 +1,12 @@
 package com.skillscan.ai.security;
 
+import com.skillscan.ai.services.TokenBlacklistService;
 import jakarta.servlet.*;
 import jakarta.servlet.http.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -16,6 +18,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwt;
     private final CustomUserDetailsService userDetailsService;
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
@@ -23,6 +26,7 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
         String header = req.getHeader("Authorization");
 
+        // ✅ No token → continue
         if (header == null || !header.startsWith("Bearer ")) {
             chain.doFilter(req, res);
             return;
@@ -31,26 +35,40 @@ public class JwtAuthFilter extends OncePerRequestFilter {
         String token = header.substring(7);
 
         try {
+
+            // ✅ FIX 1: Handle blacklist WITHOUT exception
+            if (tokenBlacklistService.isBlacklisted(token)) {
+                SecurityContextHolder.clearContext();
+                chain.doFilter(req, res);
+                return;
+            }
+
             jwt.validate(token, "access");
 
-            if (SecurityContextHolder.getContext().getAuthentication() == null){
+            if (SecurityContextHolder.getContext().getAuthentication() == null) {
 
                 String email = jwt.getEmail(token);
 
-              var userDetails  =userDetailsService.loadUserByUsername(email);
+                var userDetails = userDetailsService.loadUserByUsername(email);
 
-            var auth = new UsernamePasswordAuthenticationToken(
-                    userDetails,
-                    null,
-                    userDetails.getAuthorities()
-            );
+                var auth = new UsernamePasswordAuthenticationToken(
+                        userDetails,
+                        null,
+                        userDetails.getAuthorities()
+                );
 
-            SecurityContextHolder.getContext().setAuthentication(auth);
-        }
+                // ✅ Optional but recommended
+                auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
+
+                SecurityContextHolder.getContext().setAuthentication(auth);
+            }
+
         } catch (Exception e) {
+            // ✅ FIX 2: DO NOT force response status
             SecurityContextHolder.clearContext();
         }
 
+        // ✅ ALWAYS continue
         chain.doFilter(req, res);
     }
 }

--- a/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
+++ b/src/main/java/com/skillscan/ai/security/JwtAuthFilter.java
@@ -21,29 +21,33 @@ public class JwtAuthFilter extends OncePerRequestFilter {
     private final TokenBlacklistService tokenBlacklistService;
 
     @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        return request.getServletPath().startsWith("/api/auth/");
+    }
+
+    @Override
     protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
             throws ServletException, IOException {
 
         String header = req.getHeader("Authorization");
 
-        // ✅ No token → continue
         if (header == null || !header.startsWith("Bearer ")) {
             chain.doFilter(req, res);
             return;
         }
 
-        String token = header.substring(7);
+        String token = header.substring(7).trim();
 
         try {
 
-            // ✅ FIX 1: Handle blacklist WITHOUT exception
+            jwt.validate(token, "access");
+
             if (tokenBlacklistService.isBlacklisted(token)) {
                 SecurityContextHolder.clearContext();
-                chain.doFilter(req, res);
+                res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
                 return;
             }
 
-            jwt.validate(token, "access");
 
             if (SecurityContextHolder.getContext().getAuthentication() == null) {
 
@@ -57,18 +61,16 @@ public class JwtAuthFilter extends OncePerRequestFilter {
                         userDetails.getAuthorities()
                 );
 
-                // ✅ Optional but recommended
                 auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(req));
 
                 SecurityContextHolder.getContext().setAuthentication(auth);
             }
 
         } catch (Exception e) {
-            // ✅ FIX 2: DO NOT force response status
             SecurityContextHolder.clearContext();
+            res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
         }
-
-        // ✅ ALWAYS continue
         chain.doFilter(req, res);
     }
 }

--- a/src/main/java/com/skillscan/ai/security/JwtTokenProvider.java
+++ b/src/main/java/com/skillscan/ai/security/JwtTokenProvider.java
@@ -78,6 +78,15 @@ public class JwtTokenProvider {
 
     public String getEmail(String token) {return parse(token).get("email", String.class);}
 
+    public Date getExpiration(String token) {
+        return parse(token).getExpiration();
+    }
+
+    public long getRemainingTime(String token) {
+        Date expiration = getExpiration(token);
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
     public void validate(String token, String expectedType) {
         Claims c = parse(token);
 

--- a/src/main/java/com/skillscan/ai/services/AuthService.java
+++ b/src/main/java/com/skillscan/ai/services/AuthService.java
@@ -1,12 +1,21 @@
 package com.skillscan.ai.services;
 
 import com.skillscan.ai.dto.request.LoginRequest;
+import com.skillscan.ai.dto.request.RefreshRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
 import com.skillscan.ai.dto.response.AuthResponse;
+import com.skillscan.ai.dto.response.RefreshResponse;
+
+import java.util.Map;
 
 public interface AuthService {
 
     void register(RegisterRequest request);
 
     AuthResponse login(LoginRequest request);
+
+    void logout(String accessToken, String refreshToken);
+
+
+    RefreshResponse refresh(RefreshRequest request);
 }

--- a/src/main/java/com/skillscan/ai/services/AuthService.java
+++ b/src/main/java/com/skillscan/ai/services/AuthService.java
@@ -2,10 +2,11 @@ package com.skillscan.ai.services;
 
 import com.skillscan.ai.dto.request.LoginRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
+import com.skillscan.ai.dto.response.AuthResponse;
 
 public interface AuthService {
 
     void register(RegisterRequest request);
 
-    String login(LoginRequest request);
+    AuthResponse login(LoginRequest request);
 }

--- a/src/main/java/com/skillscan/ai/services/TokenBlacklistService.java
+++ b/src/main/java/com/skillscan/ai/services/TokenBlacklistService.java
@@ -1,0 +1,9 @@
+package com.skillscan.ai.services;
+
+
+public interface TokenBlacklistService {
+
+    void blacklistToken(String token);
+
+    boolean isBlacklisted(String token);
+}

--- a/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
@@ -122,14 +122,24 @@ public class AuthServiceImpl implements AuthService {
             throw new JwtValidationException("Refresh token is invalid");
         }
 
+        // Blacklist old refresh token
+       tokenBlacklistService.blacklistToken(refreshToken);
+
+         String newAccessToken = jwt.generateAccessToken(
+            jwt.getUserId(refreshToken),
+            jwt.getEmail(refreshToken),
+            jwt.getRole(refreshToken)
+    );
+
+    String newRefreshToken = jwt.generateRefreshToken(
+            jwt.getUserId(refreshToken),
+            jwt.getEmail(refreshToken),
+            jwt.getRole(refreshToken)
+    );
+
         return RefreshResponse.builder()
-                .accessToken(
-                        jwt.generateAccessToken(
-                                jwt.getUserId(refreshToken),
-                                jwt.getEmail(refreshToken),
-                                jwt.getRole(refreshToken)
-                        )
-                )
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
                 .build();
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
@@ -1,15 +1,19 @@
 package com.skillscan.ai.services.impl;
 
 import com.skillscan.ai.dto.request.LoginRequest;
+import com.skillscan.ai.dto.request.RefreshRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
 import com.skillscan.ai.dto.response.AuthResponse;
+import com.skillscan.ai.dto.response.RefreshResponse;
 import com.skillscan.ai.exception.EmailAlreadyExistsException;
+import com.skillscan.ai.exception.JwtValidationException;
 import com.skillscan.ai.model.User;
 import com.skillscan.ai.model.enums.UserRole;
 import com.skillscan.ai.repository.UserRepository;
 import com.skillscan.ai.security.CustomUserDetails;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.AuthService;
+import com.skillscan.ai.services.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -21,6 +25,7 @@ import org.springframework.stereotype.Service;
 import java.util.Locale;
 
 
+
 @Service
 @RequiredArgsConstructor
 @Slf4j
@@ -30,6 +35,8 @@ public class AuthServiceImpl implements AuthService {
     private final PasswordEncoder encoder;
     private final AuthenticationManager authManager;
     private final JwtTokenProvider jwt;
+
+    private final TokenBlacklistService tokenBlacklistService;
 
     @Override
     public void register(RegisterRequest request) {
@@ -91,6 +98,38 @@ public class AuthServiceImpl implements AuthService {
         return AuthResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
+                .build();
+    }
+
+    @Override
+    public void logout(String accessToken, String refreshToken) {
+
+        tokenBlacklistService.blacklistToken(accessToken);
+
+        tokenBlacklistService.blacklistToken(refreshToken);
+    }
+
+    @Override
+    public RefreshResponse refresh(RefreshRequest request) {
+
+        String refreshToken = request.getRefreshToken();
+
+        // Validate token first
+        jwt.validate(refreshToken, "refresh");
+
+        // Then check blacklist
+        if (tokenBlacklistService.isBlacklisted(refreshToken)) {
+            throw new JwtValidationException("Refresh token is invalid");
+        }
+
+        return RefreshResponse.builder()
+                .accessToken(
+                        jwt.generateAccessToken(
+                                jwt.getUserId(refreshToken),
+                                jwt.getEmail(refreshToken),
+                                jwt.getRole(refreshToken)
+                        )
+                )
                 .build();
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
@@ -58,7 +58,7 @@ public class AuthServiceImpl implements AuthService {
 
         userRepository.save(user);
 
-        log.info("User registered successfully: {}", normalizedEmail);
+         log.info("User registered successfully: userId={}", user.getId());
     }
 
     @Override
@@ -93,7 +93,7 @@ public class AuthServiceImpl implements AuthService {
                 user.getRole()
         );
 
-        log.info("Login successful for: {}", normalizedEmail);
+         log.info("User registered successfully: userId={}", user.getId());
 
         return AuthResponse.builder()
                 .accessToken(accessToken)

--- a/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/AuthServiceImpl.java
@@ -2,68 +2,95 @@ package com.skillscan.ai.services.impl;
 
 import com.skillscan.ai.dto.request.LoginRequest;
 import com.skillscan.ai.dto.request.RegisterRequest;
+import com.skillscan.ai.dto.response.AuthResponse;
 import com.skillscan.ai.exception.EmailAlreadyExistsException;
 import com.skillscan.ai.model.User;
 import com.skillscan.ai.model.enums.UserRole;
 import com.skillscan.ai.repository.UserRepository;
+import com.skillscan.ai.security.CustomUserDetails;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.AuthService;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
 import java.util.Locale;
 
+
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthServiceImpl implements AuthService {
 
-    private final UserRepository repo ;
+    private final UserRepository userRepository;
     private final PasswordEncoder encoder;
-    private  final AuthenticationManager authManager;
+    private final AuthenticationManager authManager;
     private final JwtTokenProvider jwt;
-
 
     @Override
     public void register(RegisterRequest request) {
 
-        String normalizedEmail = request.getEmail().trim().toLowerCase(Locale.ROOT);
-        if (repo.existsByEmail(normalizedEmail)) {
+        String normalizedEmail =
+                request.getEmail().trim().toLowerCase(Locale.ROOT);
+
+        if (userRepository.existsByEmail(normalizedEmail)) {
             throw new EmailAlreadyExistsException("Email already exists");
         }
+
         User user = User.builder()
                 .firstName(request.getFirstName().trim())
-                .lastName(request.getLastName())
+                .lastName(request.getLastName().trim())
                 .email(normalizedEmail)
                 .password(encoder.encode(request.getPassword()))
                 .role(UserRole.USER)
                 .build();
-        repo.save(user);
 
+        userRepository.save(user);
+
+        log.info("User registered successfully: {}", normalizedEmail);
     }
 
-
-
     @Override
-    public String login(LoginRequest request) {
+    public AuthResponse login(LoginRequest request) {
 
-        String normalizedEmail = request.getEmail().trim().toLowerCase(Locale.ROOT);
-        authManager.authenticate(
+        String normalizedEmail =
+                request.getEmail().trim().toLowerCase(Locale.ROOT);
+
+        log.debug("Login attempt for: {}", normalizedEmail);
+
+        Authentication auth = authManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
                         normalizedEmail,
                         request.getPassword()
-                ));
+                )
+        );
 
-        User user = repo.findByEmail(normalizedEmail)
-                .orElseThrow();
+        CustomUserDetails customUserDetails =
+                (CustomUserDetails) auth.getPrincipal();
 
-        return jwt.generateAccessToken(
+        User user = customUserDetails.getUser();
+
+        String accessToken = jwt.generateAccessToken(
                 user.getId(),
                 user.getEmail(),
                 user.getRole()
-
         );
+
+        String refreshToken = jwt.generateRefreshToken(
+                user.getId(),
+                user.getEmail(),
+                user.getRole()
+        );
+
+        log.info("Login successful for: {}", normalizedEmail);
+
+        return AuthResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
     }
 }

--- a/src/main/java/com/skillscan/ai/services/impl/ResumeCleanupServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/ResumeCleanupServiceImpl.java
@@ -32,6 +32,7 @@ public class ResumeCleanupServiceImpl implements ResumeCleanupService {
     private static final int MAX_RETRIES = 3;
 
 
+
     @Override
     public void processExpiredResumes() {
 

--- a/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
@@ -1,0 +1,86 @@
+package com.skillscan.ai.services.impl;
+
+import com.skillscan.ai.security.JwtTokenProvider;
+import com.skillscan.ai.services.TokenBlacklistService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.concurrent.TimeUnit;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TokenBlacklistServiceImpl implements TokenBlacklistService {
+
+    private final StringRedisTemplate redisTemplate;
+    private final JwtTokenProvider jwt;
+
+    private static final String PREFIX = "auth:blacklist:";
+
+    @Override
+    public void blacklistToken(String token) {
+
+        if (token == null || token.isBlank()) {
+            return;
+        }
+
+        try {
+            long expiry = jwt.getRemainingTime(token);
+
+            //  fallback to avoid failure on expired token
+            if (expiry <= 0) {
+                expiry = 60_000; // 1 minute
+            }
+
+            String key = PREFIX + hashToken(token);
+
+            redisTemplate.opsForValue().set(
+                    key,
+                    "1",
+                    expiry,
+                    TimeUnit.MILLISECONDS
+            );
+
+        } catch (Exception e) {
+
+            log.warn("Failed to blacklist token: {}", e.getMessage());
+        }
+    }
+
+    @Override
+    public boolean isBlacklisted(String token) {
+
+        if (token == null || token.isBlank()) {
+            return false;
+        }
+
+        try {
+            String key = PREFIX + hashToken(token);
+            return Boolean.TRUE.equals(redisTemplate.hasKey(key));
+
+        } catch (Exception e) {
+            log.warn("Blacklist check failed: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private String hashToken(String token) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
+
+            StringBuilder hex = new StringBuilder();
+            for (byte b : hash) {
+                hex.append(String.format("%02x", b));
+            }
+            return hex.toString();
+
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to hash token", e);
+        }
+    }
+}

--- a/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
@@ -79,9 +79,11 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
             return Boolean.TRUE.equals(redisTemplate.hasKey(key));
 
         } catch (Exception e) {
-            // Fail-open decision (optional: change to fail-closed if needed)
+
             log.warn("Blacklist check failed", e);
-            return false;
+            throw new TokenBlacklistException(
+                    "Authentication service unavailable"
+            );
         }
     }
 

--- a/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/TokenBlacklistServiceImpl.java
@@ -1,5 +1,7 @@
 package com.skillscan.ai.services.impl;
 
+import com.skillscan.ai.exception.TokenBlacklistException;
+import com.skillscan.ai.exception.TokenHashingException;
 import com.skillscan.ai.security.JwtTokenProvider;
 import com.skillscan.ai.services.TokenBlacklistService;
 import lombok.RequiredArgsConstructor;
@@ -28,14 +30,26 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
             return;
         }
 
-        try {
-            long expiry = jwt.getRemainingTime(token);
+        long expiry;
 
-            //  fallback to avoid failure on expired token
+
+        try {
+            expiry = jwt.getRemainingTime(token);
+
+            // Token already expired → nothing to blacklist
             if (expiry <= 0) {
-                expiry = 60_000; // 1 minute
+                log.debug("Token already expired, skipping blacklist");
+                return;
             }
 
+        } catch (Exception e) {
+            // Invalid / expired token → not a failure case
+            log.warn("Invalid or expired token during logout", e);
+            return;
+        }
+
+
+        try {
             String key = PREFIX + hashToken(token);
 
             redisTemplate.opsForValue().set(
@@ -46,8 +60,10 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
             );
 
         } catch (Exception e) {
-
-            log.warn("Failed to blacklist token: {}", e.getMessage());
+            log.error("Redis failure while blacklisting token", e);
+            throw new TokenBlacklistException(
+                    "Token could not be invalidated. Please try again."
+            );
         }
     }
 
@@ -63,12 +79,14 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
             return Boolean.TRUE.equals(redisTemplate.hasKey(key));
 
         } catch (Exception e) {
-            log.warn("Blacklist check failed: {}", e.getMessage());
+            // Fail-open decision (optional: change to fail-closed if needed)
+            log.warn("Blacklist check failed", e);
             return false;
         }
     }
 
     private String hashToken(String token) {
+
         try {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             byte[] hash = digest.digest(token.getBytes(StandardCharsets.UTF_8));
@@ -77,10 +95,14 @@ public class TokenBlacklistServiceImpl implements TokenBlacklistService {
             for (byte b : hash) {
                 hex.append(String.format("%02x", b));
             }
+
             return hex.toString();
 
         } catch (Exception e) {
-            throw new RuntimeException("Failed to hash token", e);
+            log.error("Token hashing failed", e);
+            throw new TokenHashingException(
+                    "Failed to process authentication token"
+            );
         }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -27,7 +27,7 @@ spring:
   # redis
   data:
     redis:
-      host: skillscan_redis
+      host: localhost
       port: 6379
       timeout: 6000
   #  Multipart config


### PR DESCRIPTION
## Overview
This PR introduces logout functionality for JWT-based authentication by implementing token blacklisting using Redis.

## Changes
- Added `/api/auth/logout` endpoint (authenticated)
- Implemented TokenBlacklistService with Redis storage
- Blacklisted access tokens with TTL based on expiration
- Integrated blacklist validation into JwtAuthFilter
- Ensured logout does not break even for expired tokens

## Security Improvements
- Prevents reuse of logged-out tokens
- Adds server-side control over stateless JWT logout
- Ensures only authenticated users can logout

## Testing
- Verified logout invalidates token
- Confirmed blacklisted tokens are rejected
- Tested with valid and expired tokens

## Notes
- Redis is required for token blacklist storage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Login now returns both access and refresh tokens; refresh accepts a request body DTO
  * Added logout endpoint to let users terminate sessions

* **Security**
  * Token blacklisting to prevent reuse of logged-out tokens
  * Requests now reject blacklisted tokens
  * Token utilities expose expiration/remaining-time info

* **Infrastructure**
  * Redis integration for centralized token management; app performs a Redis connectivity check at startup
<!-- end of auto-generated comment: release notes by coderabbit.ai -->