### PR TITLE
Improve LLM prompt for consistent JSON response generation

### DIFF
--- a/src/main/java/com/skillscan/ai/client/OpenAIClient.java
+++ b/src/main/java/com/skillscan/ai/client/OpenAIClient.java
@@ -59,10 +59,6 @@ public class OpenAIClient {
                 log.debug("LLM preview={}",
                         responseText.substring(0, Math.min(200, responseText.length())));
 
-                log.info("===== RAW LLM RESPONSE =====");
-                log.info(responseText);
-                log.info("============================");
-
                 String cleanJson = extractJson(sanitizeJson(responseText));
 
                 return parseSafe(cleanJson);

--- a/src/main/java/com/skillscan/ai/client/OpenAIClient.java
+++ b/src/main/java/com/skillscan/ai/client/OpenAIClient.java
@@ -59,6 +59,10 @@ public class OpenAIClient {
                 log.debug("LLM preview={}",
                         responseText.substring(0, Math.min(200, responseText.length())));
 
+                log.info("===== RAW LLM RESPONSE =====");
+                log.info(responseText);
+                log.info("============================");
+
                 String cleanJson = extractJson(sanitizeJson(responseText));
 
                 return parseSafe(cleanJson);

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -86,28 +86,51 @@ public class LLMServiceImpl implements LLMService {
     private String buildPrompt(String resumeText, String jd) {
         return """
         You are an AI resume analyzer.
-
+        
         TASK:
-        Analyze the resume and (if provided) job description.
-
-        Return ONLY valid JSON (no extra text):
-
+        Analyze the resume and (if provided) the job description.
+        
+        Return ONLY ONE valid JSON object.
+        
+        Rules:
+        - Return ONLY valid JSON.
+        - Do NOT use markdown.
+        - Do NOT wrap the response in ```json.
+        - Do NOT include explanations or any extra text.
+        - The output must be valid JSON parseable by Jackson ObjectMapper.
+        - All strings must use double quotes.
+        - Arrays must be valid JSON arrays.
+        - If there are no skills or suggestions, return an empty array [].
+        
+        JSON Schema:
+        
         {
           "score": number (0-100),
-          "skills": [],
-          "suggestions": []
+          "skills": [
+            "skill1",
+            "skill2"
+          ],
+          "suggestions": [
+            "suggestion1",
+            "suggestion2"
+          ]
         }
-
+        
+        Requirements:
+        - score must be a numeric value between 0 and 100.
+        - skills must contain only professional technical skills.
+        - suggestions must contain concise, actionable resume improvement recommendations.
+        
         RESUME:
         %s
-
+        
         JOB DESCRIPTION:
         %s
         """.formatted(
-                resumeText == null ? "" : resumeText,
-                jd == null ? "" : jd
-        );
-    }
+                        resumeText == null ? "" : resumeText,
+                        jd == null ? "" : jd
+                );
+            }
 
     //  Fallback
     private AIResponse fallback() {

--- a/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
+++ b/src/main/java/com/skillscan/ai/services/impl/LLMServiceImpl.java
@@ -100,12 +100,13 @@ public class LLMServiceImpl implements LLMService {
         - The output must be valid JSON parseable by Jackson ObjectMapper.
         - All strings must use double quotes.
         - Arrays must be valid JSON arrays.
+        - Do NOT include any keys other than "score", "skills", and "suggestions".
         - If there are no skills or suggestions, return an empty array [].
         
         JSON Schema:
         
         {
-          "score": number (0-100),
+          "score": 85,
           "skills": [
             "skill1",
             "skill2"


### PR DESCRIPTION
## Summary

Improved the LLM prompt to encourage consistent and valid JSON responses for resume analysis.

## Changes
- Refined the AI role and task instructions.
- Added stricter JSON output requirements.
- Defined a clear JSON schema with expected fields.
- Specified that `score` must be a numeric value between 0 and 100.
- Clarified formatting rules to prevent markdown and extra text.
- Improved guidance for `skills` and `suggestions` generation.

## Expected Outcome
- More reliable JSON responses from the LLM.
- Fewer JSON parsing failures.
- Improved compatibility with Jackson JSON parsing.
- More stable AI analysis pipeline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Strengthened the AI response prompt to require exactly one valid, Jackson-parseable JSON object with only `score`, `skills`, and `suggestions`, improving consistency of generated results.
  * Enhanced diagnostic logging for raw AI responses to improve visibility while processing outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->